### PR TITLE
Remove jsoninclude directive that isn't used

### DIFF
--- a/docs/conf.py
+++ b/docs/conf.py
@@ -186,35 +186,3 @@ def setup(app):
         'enable_eval_rst': True
         }, True)
     app.add_transform(AutoStructify)
-
-from sphinx.directives.code import LiteralInclude
-from docutils.parsers.rst import directives, Directive
-from docutils.parsers.rst.roles import set_classes
-
-class JSONInclude(LiteralInclude):
-    option_spec = {
-        'jsonpointer': directives.unchanged,
-        'expand': directives.unchanged,
-        'title': directives.unchanged,
-    } 
-
-    def run(self):
-        with open(self.arguments[0]) as fp:
-            json_obj = json.load(fp, object_pairs_hook=OrderedDict)
-        filename = str(self.arguments[0]).split("/")[-1].replace(".json","")
-        try:
-            title = self.options['title']
-        except KeyError as e:
-            title = filename
-        pointed = resolve_pointer(json_obj, self.options['jsonpointer'])
-        code = json.dumps(pointed, indent='    ')
-        # Ideally we would add the below to a data-expand element, but I can't see how to do this, so using classes for now...
-        class_list = self.options.get('class', [])
-        class_list.append('file-'+title)
-        expand = str(self.options.get("expand","")).split(",")
-        class_list = class_list + ['expandjson expand-{0}'.format(s.strip()) for s in expand]
-        literal = nodes.literal_block(code, code, classes=class_list)
-        literal['language'] = 'json' 
-        return [ literal ]
-
-directives.register_directive('jsoninclude', JSONInclude)


### PR DESCRIPTION
If we want to use jsoninclude in future, we should get it by installing [sphinxcontrib-opendataservices](https://github.com/OpenDataServices/sphinxcontrib-opendataservices/) instead.