### PR TITLE
Testing statement order

### DIFF
--- a/tests/data/bods-package/fails-secondary-validation/bods-package-incorrect-ordering.json
+++ b/tests/data/bods-package/fails-secondary-validation/bods-package-incorrect-ordering.json
@@ -1,0 +1,73 @@
+[
+  {
+    "statementID":"1dc0e987-5c57-4a1c-b3ad-61353b66a9b7",
+    "statementType":"entityStatement",
+    "groupID":"f25fb48c-ab3b-44e3-aaa5-45fb5930f769",
+    "statementDate":"2017-11-18",
+    "entityType":"registeredEntity",
+    "name":"CHRINON LTD",
+    "foundingDate":"2010-11-18",
+    "identifiers":[
+      {
+        "scheme":"GB-COH",
+        "id":"07444723"
+      }
+    ]
+  },
+  {
+    "statementID":"fbfd0547-d0c6-4a00-b559-5c5e91c34f5c",
+    "statementType":"beneficialOwnershipStatement",
+    "groupID":"f25fb48c-ab3b-44e3-aaa5-45fb5930f769",
+    "statementDate":"2017-11-18",
+    "subject":{
+      "entity":{
+        "type":"entityStatement",
+        "describedByStatement":"1dc0e987-5c57-4a1c-b3ad-61353b66a9b7"
+      }
+    },
+    "interestedParty":{
+      "person":{
+        "type":"personStatement",
+        "describedByStatement":"019a93f1-e470-42e9-957b-03559861b2e2"
+      }
+    },
+    "interests":[
+      {
+        "type":"shareholding",
+        "interestLevel":"direct",
+        "startDate":"2016-04-06",
+        "share":{
+          "exact":100
+        }
+      }
+    ]
+  },
+    {
+    "statementID":"019a93f1-e470-42e9-957b-03559861b2e2",
+    "groupID":"f25fb48c-ab3b-44e3-aaa5-45fb5930f769",
+    "statementType":"personStatement",
+    "statementDate":"2017-11-18",
+    "personType":"knownPerson",
+    "name":"Chris Taggart",
+    "nationalities":[
+      "GB"
+    ],
+    "alternateNames":[
+      {
+        "type":"detailed",
+        "fullName":"Christopher Taggart",
+        "givenName":"Christopher",
+        "familyName":"Taggart"
+      }
+    ],
+    "birthDate":"1964-04",
+    "addresses":[
+      {
+        "type":"service",
+        "address":"Aston House, Cornwall Avenue, London",
+        "country":"GB",
+        "postCode":"N3 1LF"
+      }
+    ]
+  }
+]

--- a/tests/test_data.py
+++ b/tests/test_data.py
@@ -67,6 +67,7 @@ def test_invalid_statement_json(json_path, error):
         'data/beneficial-ownership-statement/invalid/beneficial-ownership-statement-no-statement-type.json',
     ], MissingStatementTypeError),
     ('data/bods-package/fails-secondary-validation/bods-package-missing-entity-statement.json', None, UnrecognisedStatementID),
+    ('data/bods-package/fails-secondary-validation/bods-package-incorrect-ordering.json', None, UnrecognisedStatementID),
 ])
 def test_invalid_package_json(json_path, json_paths, error):
     if json_path:
@@ -138,6 +139,9 @@ def test_invalid_statement_json_iter_errors(json_path, expected_errors):
     }),
     ('data/bods-package/fails-secondary-validation/bods-package-missing-entity-statement.json', None, {
         "subject/entitiy/describedByStatement '1dc0e987-5c57-4a1c-b3ad-61353b66a9b7' does not match any known entities"
+    }),
+    ('data/bods-package/fails-secondary-validation/bods-package-incorrect-ordering.json', None, {
+        "interestedParty/person/describedByStatement '019a93f1-e470-42e9-957b-03559861b2e2' does not match any known persons"
     }),
 ])
 def test_invalid_package_json_iter_errors(json_path, json_paths, expected_errors):


### PR DESCRIPTION
In relation to #59, a file should also fail validation when:

* All the statements referenced by a beneficial ownership statement are present **but** the beneficial ownership statement occurs **before** the statements that it references.