### PR TITLE
45 loose validation

### DIFF
--- a/examples/flat-serialisation/gb-coh-bods-package.json
+++ b/examples/flat-serialisation/gb-coh-bods-package.json
@@ -10,7 +10,8 @@
     "identifiers":[
       {
         "scheme":"GB-COH",
-        "id":"07444723"
+        "id":"07444723",
+        "validationType": "strict"
       }
     ]
   },

--- a/examples/flat-serialisation/gb-coh-bods-package.json
+++ b/examples/flat-serialisation/gb-coh-bods-package.json
@@ -22,9 +22,13 @@
     "statementDate":"2017-11-18",
     "personType":"knownPerson",
     "name":"Chris Taggart",
-    "nationalities":[
-      "GB"
-    ],
+    "nationalities":
+     {
+      "validated":
+        [
+          "GB"
+        ]
+     },
     "alternateNames":[
       {
         "type":"detailed",

--- a/examples/flat-serialisation/gb-coh-entity-statement.json
+++ b/examples/flat-serialisation/gb-coh-entity-statement.json
@@ -9,7 +9,8 @@
   "identifiers": [
     {
       "scheme": "GB-COH",
-      "id": "07444723"
+      "id": "07444723",
+      "validationType": "strict"
     }
   ]
 }

--- a/examples/flat-serialisation/gb-coh-person-statement.json
+++ b/examples/flat-serialisation/gb-coh-person-statement.json
@@ -5,9 +5,13 @@
   "statementDate": "2017-11-18",
   "personType": "knownPerson",
   "name": "Chris Taggart",
-  "nationalities": [
-      "GB"
-    ],
+  "nationalities":
+   {
+    "validated":
+      [
+        "GB"
+      ]
+   },
   "alternateNames": [
     {
       "type": "detailed",

--- a/schema/components.json
+++ b/schema/components.json
@@ -140,6 +140,12 @@
       "description":"An identifier that has been assigned to this entity. The scheme or list from which the identifier is drawn should be declared. ",
       "type":"object",
       "properties":{
+        "validationType": {
+          "title": "The type of validation used on this identifier.",
+          "description": "Should this object be strictly validated?",
+          "type": "string",
+          "enum": ["strict"]
+        },
         "id":{
           "title":"ID",
           "description":"The identifier for this entity as provided in the declared scheme.",
@@ -156,7 +162,38 @@
           "type":"string",
           "format":"uri"
         }
-      }
+      },
+      "required": ["validationType"]
+    },
+    "UnvalidatedIdentifier":{
+      "title":"Unvalidated Identifier",
+      "description":"An identifier that has been assigned to this entity. The scheme or list from which the identifier is drawn should be declared. ",
+      "type":"object",
+      "properties":{
+        "validationType": {
+          "title": "The type of validation used on this identifier.",
+          "description": "Should this object be strictly validated?",
+          "type": "string",
+          "enum": ["loose"]
+        },
+        "id":{
+          "title":"ID",
+          "description":"The identifier for this entity as provided in the declared scheme.",
+          "type":"string"
+        },
+        "scheme":{
+          "title":"Scheme",
+          "description":"For entity statements, the scheme should be a register name. For person statements, recognised values include 'passport', 'internal' and 'id-card'.",
+          "type":"string"
+        },
+        "uri":{
+          "title":"URI",
+          "description":"Where this identifier has a [canonical URI](https://en.wikipedia.org/wiki/Uniform_Resource_Identifier) this may be included",
+          "type":"string",
+          "format":"uri"
+        }
+      },
+      "required": ["validationType"]
     },
     "ID":{
       "title":"ID",

--- a/schema/entity-statement.json
+++ b/schema/entity-statement.json
@@ -50,12 +50,24 @@
         "minLength": 2,
         "maxLength": 10
       },
+      "unvalidatedJurisdiction": {
+        "title": "Jurisdiction",
+        "description": "The jurisdiction in which this entity is registered, as a string. The jusrisdiction should either be a country or the sub-national state or region that has relevant jurisdiction over the registration of operation of this entity.",
+        "type": "string"
+      },
       "identifiers": {
         "title": "Identifiers",
         "description": "One or more official identifiers for this entity. Where available, official registration numbers should be provided.",
         "type": "array",
         "items": {
-          "$ref": "components.json#/definitions/Identifier"
+          "oneOf": [
+            {
+             "$ref": "components.json#/definitions/Identifier"
+            },
+                      {
+             "$ref": "components.json#/definitions/UnvalidatedIdentifier"
+            }
+          ]
         }
       },
       "foundingDate": {

--- a/schema/person-statement.json
+++ b/schema/person-statement.json
@@ -60,11 +60,26 @@
     "nationalities": {
       "title": "Nationality",
       "description": "An array of ISO 2-Digit country codes representing nationalities held by this individual.",
-      "type": "array",
-      "items": {
-        "type": "string",
-        "maxLength": 2,
-        "minLength": 2
+      "type": "object",
+      "properties":
+      {
+        "validated": {
+          "title": "Validated nationalities",
+          "description": "An array of ISO 2-Digit country codes representing nationalities held by this individual.",
+          "type": "array",
+          "items": {
+            "type": "string",
+            "maxLength": 2,
+            "minLength": 2
+          }
+        },
+        "unvalidated": {
+          "title": "Unvalidated nationalities",
+          "description": "An array of strings representing nationalities held by this individual",
+          "items": {
+            "type": "string"
+          }
+        }
       }
     },
     "placeOfResidence": {

--- a/tests/data/bods-package/fails-secondary-validation/bods-package-missing-entity-statement.json
+++ b/tests/data/bods-package/fails-secondary-validation/bods-package-missing-entity-statement.json
@@ -6,9 +6,13 @@
     "statementDate":"2017-11-18",
     "personType":"knownPerson",
     "name":"Chris Taggart",
-    "nationalities":[
-      "GB"
-    ],
+    "nationalities":
+     {
+      "validated":
+        [
+          "GB"
+        ]
+     },
     "alternateNames":[
       {
         "type":"detailed",

--- a/tests/data/bods-package/valid/valid-bods-package-loose-validation.json
+++ b/tests/data/bods-package/valid/valid-bods-package-loose-validation.json
@@ -1,0 +1,63 @@
+[
+  {
+    "statementID":"eaa57b0d-2920-4b4b-a465-708994497774",
+    "statementType":"entityStatement",
+    "groupID":"9d3a6ff3-6cc4-436f-85dc-cd7ac853d3f7",
+    "statementDate":"2018-02-28",
+    "entityType":"registeredEntity",
+    "jurisdiction": "GB",
+    "name":"CJ ICM (UK) LTD",
+    "foundingDate":"1996-06-07",
+    "identifiers":[
+      {
+        "scheme":"GB-COH",
+        "id":"03209262",
+        "validationType": "strict"
+      }
+    ]
+  },
+  {
+    "statementID":"1dc0e987-5c57-4a1c-b3ad-61353b66a9b7",
+    "statementType":"entityStatement",
+    "groupID":"9d3a6ff3-6cc4-436f-85dc-cd7ac853d3f7",
+    "statementDate":"2016-06-30",
+    "entityType":"registeredEntity",
+    "unvalidatedJurisdiction": "Uae",
+    "name":"Ibrakom Fzco",
+    "identifiers":[
+      {
+        "scheme":"Jebel Ali Free Zone",
+        "id":"00335",
+        "validationType": "loose"
+      }
+    ]
+  },
+  {
+    "statementID":"611e4aec-9da8-44f5-a03b-b7382111d84f",
+    "statementType":"beneficialOwnershipStatement",
+    "groupID":"9d3a6ff3-6cc4-436f-85dc-cd7ac853d3f7",
+    "statementDate":"2017-11-18",
+    "subject":{
+      "entity":{
+        "type":"entityStatement",
+        "describedByStatement":"eaa57b0d-2920-4b4b-a465-708994497774"
+      }
+    },
+    "interestedParty":{
+      "entity":{
+        "type":"entityStatement",
+        "describedByStatement":"1dc0e987-5c57-4a1c-b3ad-61353b66a9b7"
+      }
+    },
+    "interests":[
+      {
+        "type":"shareholding",
+        "interestLevel":"direct",
+        "share":{
+          "minimum":75,
+          "maximum": 100
+        }
+      }
+    ]
+  }
+]

--- a/tests/data/bods-package/valid/valid-bods-package.json
+++ b/tests/data/bods-package/valid/valid-bods-package.json
@@ -5,12 +5,14 @@
     "groupID":"f25fb48c-ab3b-44e3-aaa5-45fb5930f769",
     "statementDate":"2017-11-18",
     "entityType":"registeredEntity",
+    "jurisdiction": "GB",
     "name":"CHRINON LTD",
     "foundingDate":"2010-11-18",
     "identifiers":[
       {
         "scheme":"GB-COH",
-        "id":"07444723"
+        "id":"07444723",
+        "validationType": "strict"
       }
     ]
   },

--- a/tests/data/bods-package/valid/valid-bods-package.json
+++ b/tests/data/bods-package/valid/valid-bods-package.json
@@ -23,9 +23,13 @@
     "statementDate":"2017-11-18",
     "personType":"knownPerson",
     "name":"Chris Taggart",
-    "nationalities":[
-      "GB"
-    ],
+    "nationalities":
+     {
+      "validated":
+        [
+          "GB"
+        ]
+     },
     "alternateNames":[
       {
         "type":"detailed",

--- a/tests/data/entity-statement/invalid/entity-statement-with-invalid-statement-id-no-entity-type.json
+++ b/tests/data/entity-statement/invalid/entity-statement-with-invalid-statement-id-no-entity-type.json
@@ -9,7 +9,8 @@
   "identifiers": [
     {
       "scheme": "GB-COH",
-      "id": "07444723"
+      "id": "07444723",
+      "validationType": "strict"
     }
   ]
 }

--- a/tests/data/entity-statement/invalid/entity-statement-with-invalid-statement-id.json
+++ b/tests/data/entity-statement/invalid/entity-statement-with-invalid-statement-id.json
@@ -10,7 +10,8 @@
   "identifiers": [
     {
       "scheme": "GB-COH",
-      "id": "07444723"
+      "id": "07444723",
+      "validationType": "strict"
     }
   ]
 }

--- a/tests/data/entity-statement/valid/valid-entity-statement.json
+++ b/tests/data/entity-statement/valid/valid-entity-statement.json
@@ -9,7 +9,8 @@
   "identifiers": [
     {
       "scheme": "GB-COH",
-      "id": "07444723"
+      "id": "07444723",
+      "validationType": "strict"
     }
   ]
 }

--- a/tests/data/person-statement/invalid/person-statement-with-bad-date.json
+++ b/tests/data/person-statement/invalid/person-statement-with-bad-date.json
@@ -5,9 +5,13 @@
   "statementDate": "Tuesday",
   "personType": "knownPerson",
   "name": "Chris Taggart",
-  "nationalities": [
-      "GB"
-    ],
+  "nationalities":
+   {
+    "validated":
+      [
+        "GB"
+      ]
+   },
   "alternateNames": [
     {
       "type": "detailed",

--- a/tests/data/person-statement/invalid/person-statement-with-invalid-statement-id.json
+++ b/tests/data/person-statement/invalid/person-statement-with-invalid-statement-id.json
@@ -5,9 +5,13 @@
   "statementDate": "2017-11-18",
   "personType": "knownPerson",
   "name": "Chris Taggart",
-  "nationalities": [
-      "GB"
-    ],
+  "nationalities":
+   {
+    "validated":
+      [
+        "GB"
+      ]
+   },
   "alternateNames": [
     {
       "type": "detailed",

--- a/tests/data/person-statement/valid/valid-person-statement.json
+++ b/tests/data/person-statement/valid/valid-person-statement.json
@@ -5,9 +5,13 @@
   "statementDate": "2017-11-18",
   "personType": "knownPerson",
   "name": "Chris Taggart",
-  "nationalities": [
-      "GB"
-    ],
+  "nationalities":
+   {
+    "validated":
+      [
+        "GB"
+      ]
+   },
   "alternateNames": [
     {
       "type": "detailed",


### PR DESCRIPTION
To accommodate existing sources of data, we will need a method of relaxing validation for certain fields that, in the beta release, were either validated by the schema or intended to be validated using secondary methods. This includes:

- `nationalities` - for describing nationalities held by a natural person using ISO 2-Digit country code;
- `jurisdiction` - the ISO_3166-2 2-Digit country code, or ISO_3166-2 sub-division code of the responsible jurisdiction of an entity; and,
- `scheme` in the `Identifier` object. This uniquely identifies a register for a identification number, using org-id lists.

This PR is a first pass at representing loosely validated data on jurisdictions and scheme.

The [example data](https://github.com/openownership/data-standard/blob/2cc213be3d6b95bf67fcf0641f3fccd8f6738dbf/tests/data/bods-package/valid/valid-bods-package-loose-validation.json) is taken from this [company](https://beta.companieshouse.gov.uk/company/03209262/persons-with-significant-control) in the UK PSC register. Strict validation would remove a lot of the information contained in the declaration, even if it is a signal, rather than a definite statement of the legal owner of the company.