### PR TITLE
Suggested primer updates

### DIFF
--- a/docs/conf.py
+++ b/docs/conf.py
@@ -31,7 +31,7 @@ from recommonmark.parser import CommonMarkParser
 # Add any Sphinx extension module names here, as strings. They can be
 # extensions coming with Sphinx (named 'sphinx.ext.*') or your custom
 # ones.
-extensions = ['sphinxcontrib.jsonschema']
+extensions = ['sphinxcontrib.jsonschema','sphinxcontrib.opendataservices']
 
 # Add any paths that contain templates here, relative to this directory.
 templates_path = ['_templates']

--- a/docs/data.md
+++ b/docs/data.md
@@ -1,17 +1,16 @@
 Data Schema
 ===========
 
-This data schema sets out how beneficial ownership data **must** (or **should** be) structured and formatted in order to [conform](conformance.md) to the Beneficial Ownership Data Standard.
+This data schema sets out how beneficial ownership data **must** (or **should**) be structured and formatted in order to [conform](conformance.md) to the Beneficial Ownership Data Standard (BODS).
 
-People working on data management systems implementing the Standard will want to understand the [concepts](modelling-beneficial-ownership-info.md) on which the Standard is modelled. The [schema browser](data-schema-browser.md) provides a way of digging through the schema's structure, showing how its objects and fields fit together. Alternatively, the [schema reference](data-schema-reference.md) presents these elements and their descriptions in easy-to-reference tables. Further considerations regarding the validation, publishing, and lifecycle of data are included as [technical requirements](technical-requirements.md).
-
+People working on data management systems implementing BODS will want to understand the [concepts](modelling-beneficial-ownership-info.md) on which the standard is modelled. The [schema browser](data-schema-browser.md) provides a way of digging through the schema's structure, showing how its objects and fields fit together. Alternatively, the [schema reference](data-schema-reference.md) presents these elements and their descriptions in easy-to-reference tables. Further considerations regarding the validation, publishing, and lifecycle of data are included as [technical requirements](technical-requirements.md).
 
 
 ```eval_rst
-
 .. highlights:: 
-    
-    **Must** and **should** are used in the schema to denote required and recommended elements of the Standard, as defined in [RFC2119](https://tools.ietf.org/html/rfc2119).
+    .. markdown::
+        **Must** and **should** are used in the schema to denote required and recommended elements of the Standard, as defined in [RFC2119](https://tools.ietf.org/html/rfc2119).
+
 
 ```
 

--- a/docs/modelling-beneficial-ownership-info.md
+++ b/docs/modelling-beneficial-ownership-info.md
@@ -18,8 +18,6 @@ Details of the subject of a beneficial ownership statement and its interested pa
 
 ![A Beneficial ownership statement block containing two 'interests': one a 60% share-holding interest, the other a 30% voting-rights interest](_assets/data-schema-model-2.svg)
 
-
-
 ## Statements as claims
 
 Each statement represents a claim about beneficial ownership made by a particular source at a particular point in time.
@@ -30,9 +28,9 @@ Modelling beneficial ownership information in this way allows us to make sense o
 
 * Statements about beneficial ownership to conflict.
 * Statements about beneficial ownership to overlap.
-* Production of historical beneficial ownership snapshots: what was known when. (Known as [bi-temporal modelling](https://en.wikipedia.org/wiki/Bitemporal_Modeling).)
+* Production of historical beneficial ownership snapshots: what was known when ([bi-temporal modelling](https://en.wikipedia.org/wiki/Bitemporal_Modeling)).
 
-When representing data conforming to the Standard, users should therefore handle statements with due care. Ultimately it is up to data consumers to decide which statements to trust (and to verify identities using the [identifying information](identifiers.md) contained in person and entity statements).
+When representing data conforming to BODS, users should therefore handle statements with due care. Ultimately it is up to data consumers to decide which statements to trust, and to verify identities using the [identifying information](identifiers.md) contained in person and entity statements.
 
 
 ## Anatomy of a statement - the data model

--- a/docs/whatdoesbodscover.md
+++ b/docs/whatdoesbodscover.md
@@ -2,7 +2,7 @@
 
 <h2>A broad, flexible range of fields and options...</h2>
 
-The Beneficial Ownership Data Standard allows publishers to include:
+The Beneficial Ownership Data Standard (BODS) allows publishers to provide statements that describe:
 
 * [Identifiers](identifiers.md) and [details](data-schema-reference.md#personstatement) for individuals
 * [Identifiers](identifiers.md) and [details](data-schema-reference.md#entitystatement) for companies
@@ -20,11 +20,11 @@ The [design](modelling-beneficial-ownership-info.md) of the Standard allows:
 
 * Changes to beneficial ownership information to be tracked over time.
 * Competing claims about beneficial ownership to be considered alongside one another.
-* Publishers to use whatever definition of beneficial ownership is relevant to them.
+* Publishers to use the definitions of beneficial ownership provided by the relevant law or policy framework they are operating under.
 
-Although the Data Standard is not a data model for the storage of beneficial ownership information, it can inform the design of data collection and storage systems. A set of [functional requirements](functional-requirements.md) for such databases and systems is available for this purpose.
+Although BODS is not a data model for the storage of beneficial ownership information, it can inform the design of data collection and storage systems. A set of [functional requirements](functional-requirements.md) for such databases and systems is available for this purpose.
 
-In order to enable worldwide use of the Standard, thresholds for meeting beneficial ownership criteria are undefined. Instead, each statement of beneficial ownership expressed using the Standard describes the degree of ownership or control.
+In order to enable worldwide use of the Standard, it does not directly define thresholds for meeting beneficial ownership criteria. Instead, each statement of beneficial ownership expressed using the Standard can describe the degree of ownership or control, allowing each implementer of the standard to set their own thresholds. 
 
 ```eval_rst 
 

--- a/docs/whatisbodata.md
+++ b/docs/whatisbodata.md
@@ -1,10 +1,10 @@
 # What is beneficial ownership data?
 
-<h2>From people's birth places to rules about shareholders' voting rights...</h2>
+<h2>From owners' birth places to rules about shareholders' voting rights...</h2>
 
 Data relating to beneficial ownership may include:
 
-* Details of individuals
+* Details to identify individual owners
 * Details of other legal entities
 * A breakdown of share holdings 
 * The voting rights attached to different share classes
@@ -13,7 +13,7 @@ Data relating to beneficial ownership may include:
 
 And so on.
 
-<h2>...data clarifying beneficial ownership is often scattered across documents...</h2>
+<h2>...data describing beneficial ownership is often scattered across documents...</h2>
 
 The data is often included in companies’ annual reports, founding articles and filings to regulatory authorities. Bringing it all together can build the big picture about a company’s beneficial owners.
 
@@ -40,7 +40,7 @@ These challenges require us to structure and standardise beneficial ownership da
 
 .. highlights:: 
     
-    Companies already hold data about beneficial ownership. Historically it has not been in a consistent format that facilitates reporting requirements. 
+    Companies already hold data about beneficial ownership. It is not always recorded, stored or shared in consistent ways, making reporting and interpreting reports challenging. 
 
 ```
 

--- a/docs/whatisthebods.md
+++ b/docs/whatisthebods.md
@@ -1,43 +1,41 @@
 # What is the Beneficial Ownership Data Standard?
 
-The value from beneficial ownership data comes when we can share it easily, knowing that it will be correctly understood. Data from different companies and different countries can then be combined, analysed and visualised.
+The value from beneficial ownership data comes when we can share it easily, knowing that it will be correctly understood. Data from different companies and different countries can then be combined, visualised, explored and analysed.
 
 <h2>To gain insights about beneficial ownership...</h2>
 
-Bringing together data from a variety of sources can give us insights into sprawling or complicated ownership and control structures. But processing, combining and analysing data that exists in a multitude of formats is extremely difficult and time-consuming.
+Bringing together data from a variety of sources can give us insights into sprawling or complicated ownership and control structures. But, without common standards, combining and analysing data from different sources can be extremely difficult, expensive and time-consuming.
 
 ![Data sources separately feeding into an unclear picture.](_assets/Diag7-dataStandardBlackBox.svg)
 
-Without a consistent approach to organizing the beneficial ownership data the bigger picture remains obscure. 
+When we only have scattered documents to draw upon, the bigger picture of beneficial ownership remains obscure. 
 
 <h2>...data must be shared in standardised way...</h2>
 
-The Beneficial Ownership Data Standard provides a structured data format plus guidance for collecting, sharing and using data on beneficial ownership:
+The Beneficial Ownership Data Standard (BODS) provides a structured data format, along with guidance for collecting, sharing and using data on beneficial ownership:
 
-* The [Data schema](data.md) describes how and what data should be shared. It can also inform the design of data collection and management systems;
+* The [data schema](data.md) describes how and what data should be shared. It can also inform the design of data collection and management systems;
 
-* The [User guides](userguides.md) give support for publishers and users of the data.
+* The [user guides](userguides.md) give support for publishers and users of the data.
 
 ![A standardised 'template' for data makes processing it easier, leading to a clear picture.](_assets/Diag8-dataStandardTemplate.svg)
 
 
-Using the Standard simplifies the sharing and use of beneficial ownership information.
-
+Using BODS simplifies the sharing and use of beneficial ownership information.
 
 <h2>...as structured data.</h2>
 
-The data schema describes how data about the beneficial owners of a legal entity can be organized and stored. The schema is defined in a structured data format called JSON.
+The data schema describes how data about the beneficial owners of a legal entity can be organized and exchanged. The schema is defined in a structured data format called JSON.
 
-![A two-column diagram. A company document containing beneficial ownership information: the related JSON code on the right.](_assets/Diag9-JSONdata.svg)
+![Company documents containing beneficial ownership information: the related structured data representation of these documents is on the right.](_assets/Diag9-JSONdata.svg)
 
-Using the popular JSON format facilitates computerised access and analysis of the data. The format is also human-readable.
-
+Using the popular JSON format facilitates computerised access and analysis of the data, whilst also providing human-readable data. 
 
 ```eval_rst 
 
 .. highlights:: 
     
-    The **Beneficial Ownership Data Standard** describes what data should be shared and how (as a JSON schema) and provides guidance on data publishing processes and data use.
+    The **Beneficial Ownership Data Standard** describes what data should be shared and how (using a JSON schema) and provides guidance on data publishing processes and data use.
 
 ``` 
 


### PR DESCRIPTION
This PR contains:

* A minor configuration update so we can use [all the Open Data Services Sphinx directives](https://sphinxcontrib-opendataservices.readthedocs.io/en/latest/misc/);
* Some suggested updates to phrasing, mostly in the primer;

One thing amongst these changes is a stylistic tweak, which I don't mind seeing reverted if Kadie/Jack have strong opinions otherwise on it: this change was to prefer referring to 'BODS' over 'the Standard', as the capitalisation of 'Standard' and 'Data Standard' didn't feel quite right to me. 

@kd-ods If you got chance to look at this PR before on leave and just let me know if anything you would object to heavily, that would be much appreciated, as I'll then also try some refactoring in terms of structuring markdown files in folders just for easier maintenance and governance. 