### PR TITLE
PEP status in person

### DIFF
--- a/schema/components.json
+++ b/schema/components.json
@@ -373,6 +373,33 @@
           "minLength": 2
         }
       }
+    },
+    "PepStatus":{
+      "title": "PEP Status",
+      "description": "A description of a politically-exposed person status.",
+      "type": "object",
+      "properties": {
+        "reason": {
+          "title": "Reason",
+          "description": "The reason for this person being declared a politically-exposed person.",
+          "type": "string"
+        },
+        "jurisdiction": {
+          "$ref": "#/definitions/Jurisdiction"
+        },
+        "startDate":{
+          "title":"State date",
+          "description":"When did this PEP status begin. Please provide as precise a date as possible in ISO 8601 format. When only the year or year and month is known, these can be given as YYYY or YYYY-MM.",
+          "type":"string",
+          "pattern":"^([\\+-]?\\d{4}(?!\\d{2}\b))((-?)((0[1-9]|1[0-2])(\\3([12]\\d|0[1-9]|3[01]))?|W([0-4]\\d|5[0-2])(-?[1-7])?|(00[1-9]|0[1-9]\\d|[12]\\d{2}|3([0-5]\\d|6[1-6])))([T\\s]((([01]\\d|2[0-3])((:?)[0-5]\\d)?|24\\:?00)([\\.,]\\d+(?!:))?)?(\\17[0-5]\\d([\\.,]\\d+)?)?([zZ]|([\\+-])([01]\\d|2[0-3]):?([0-5]\\d)?)?)?)?$"
+        },
+        "endDate":{
+          "title":"End date",
+          "description":"When did this PEP status end. Please provide as precise a date as possible in ISO 8601 format. When only the year or year and month is known, these can be given as YYYY or YYYY-MM.",
+          "type":"string",
+          "pattern":"^([\\+-]?\\d{4}(?!\\d{2}\b))((-?)((0[1-9]|1[0-2])(\\3([12]\\d|0[1-9]|3[01]))?|W([0-4]\\d|5[0-2])(-?[1-7])?|(00[1-9]|0[1-9]\\d|[12]\\d{2}|3([0-5]\\d|6[1-6])))([T\\s]((([01]\\d|2[0-3])((:?)[0-5]\\d)?|24\\:?00)([\\.,]\\d+(?!:))?)?(\\17[0-5]\\d([\\.,]\\d+)?)?([zZ]|([\\+-])([01]\\d|2[0-3]):?([0-5]\\d)?)?)?)?$"
+        }
+      }
     }
   }
 }

--- a/schema/person-statement.json
+++ b/schema/person-statement.json
@@ -91,6 +91,14 @@
         "$ref": "components.json#/definitions/Annotation"
       }
     },
+    "pep_status": {
+      "title": "PEP Status",
+      "description": "One or more descriptions of this person's Politically-Exposed Person status.",
+      "type": "array",
+      "items": {
+        "$ref": "components.json#definitions/PepStatus"
+      }
+    },
     "replacesStatement": {
       "$ref": "components.json#/definitions/ReplacesStatement"
     }

--- a/schema/person-statement.json
+++ b/schema/person-statement.json
@@ -91,9 +91,9 @@
         "$ref": "components.json#/definitions/Annotation"
       }
     },
-    "pep_status": {
-      "title": "PEP Status",
-      "description": "One or more descriptions of this person's Politically-Exposed Person status.",
+    "pepStatus": {
+      "title": "Politically Exposed Person Status",
+      "description": "One or more descriptions of this person's Politically-Exposed Person (PEP) status.",
       "type": "array",
       "items": {
         "$ref": "components.json#definitions/PepStatus"


### PR DESCRIPTION
Adds a simple model for politically-exposed person status.

Links to specific organisations, or to other people, can be provided using annotations with type `commenting` or `linking`. Sources can be provided at the statement level or, where more precision is needed, using an annotation.

Note that a more sophisticated modelling of PEPs is probably beyond the scope of the data standard at present and the focus should be on allowing users of beneficial ownership data to link to other existing sources on people. 