### PR TITLE
Annotations for schema-beta-2

### DIFF
--- a/schema/components.json
+++ b/schema/components.json
@@ -308,7 +308,7 @@
           "Title": "Motivation",
           "Description": "The motivation for this annotation, chosen from a codelist. Commenting should be used with the description field to add contextual comments to a field or statement. Correcting should be used to indicate that original material has been corrected, using the method in the description field. Identifying should be used when original data has been augmented or processed for the purpose of identifying natural persons or legal entities, using the method in the description field. Linking should be used to provide contextual material that explains the statement or field; URLs to linked material can be provided in the source field. Provenance should be used to identify the source of information at a statement or field level. Transformation should be used to describe how data has in fields has been changed from its original form. The new form MAY be provided in the transformedContent field.",
           "type": "string",
-          "enum": ["commenting", "correcting", "identifying", "linking", "provenance", "transformation"]
+          "enum": ["commenting", "correcting", "identifying", "linking", "transformation"]
         },
         "description":{
           "type":"string",
@@ -324,7 +324,7 @@
       "anyOf": [
         {
           "properties": {
-            "motivation": { "enum": [ "provenance"] }
+            "motivation": { "enum": [ "linking"] }
           },
           "required": ["statementPointerTarget", "motivation"]
         },

--- a/schema/components.json
+++ b/schema/components.json
@@ -299,9 +299,6 @@
         "createdBy":{
           "title": "Created By",
           "description": "The person, organisation or agent that created this annotation.",
-          "type": "array",
-          "items": {
-            "$ref": "#/definitions/Agent"
           "type": "object",
           "properties": {
             "name":{
@@ -319,7 +316,7 @@
         },
         "motivation": {
           "title": "Motivation",
-          "description": "The motivation for this annotation, chosen from a codelist. Commenting should be used with the description field to add contextual comments to a field or statement. Correcting should be used to indicate that original material has been corrected, using the method in the description field. Identifying should be used when original data has been augmented or processed for the purpose of identifying natural persons or legal entities, using the method in the description field. Linking should be used to provide contextual material that explains the statement or field; URLs to linked material can be provided in the source field. Provenance should be used to identify the source of information at a statement or field level. Transformation should be used to describe how data has in fields has been changed from its original form. The new form MAY be provided in the transformedContent field.",
+          "description": "The motivation for this annotation, chosen from a codelist. Commenting should be used with the description field to add contextual comments to a field or statement. Correcting should be used to indicate that original material has been corrected, using the method in the description field. Identifying should be used when original data has been augmented or processed for the purpose of identifying natural persons or legal entities, using the method in the description field. Linking should be used to provide contextual material that explains the statement or field; URLs to linked material can be provided in the url field. Provenance should be used to identify the source of information at a statement or field level. Transformation should be used to describe how data has in fields has been changed from its original form. The new form MAY be provided in the transformedContent field.",
           "type": "string",
           "enum": ["commenting", "correcting", "identifying", "linking", "transformation"]
         },
@@ -332,6 +329,12 @@
           "type": "string",
           "title": "Transformed content",
           "description": "A representation of the annotation target after the transformation in the description field has been applied. This field SHOULD only be used when the motivation is transformation."
+        },
+        "url": {
+          "title": "URL",
+          "description": "A linked resource that annotates, provides context for or enhances this statement. The content of the resource, or the relationship to the statement, MAY be described in the description field.",
+          "type":"string",
+          "format": "uri"
         }
       },
       "anyOf": [

--- a/schema/components.json
+++ b/schema/components.json
@@ -311,9 +311,9 @@
           "enum": ["commenting", "correcting", "identifying", "linking", "transformation"]
         },
         "description":{
-          "type":"string",
           "title":"Description",
-          "description":"A free-text description to annotate this statment or field."
+          "description":"A free-text description to annotate this statment or field.",
+          "type":"string"
         },
         "transformedContent": {
           "type": "string",

--- a/schema/components.json
+++ b/schema/components.json
@@ -302,6 +302,19 @@
           "type": "array",
           "items": {
             "$ref": "#/definitions/Agent"
+          "type": "object",
+          "properties": {
+            "name":{
+              "title":"Name",
+              "description":"The name of the person, organisation or agent that created this annotation.",
+              "type":"string"
+            },
+            "uri":{
+              "title":"URI",
+              "description":"An optional URI to identify person, organisation or agent that created this annotation.",
+              "type":"string",
+              "format":"uri"
+            }
           }
         },
         "motivation": {

--- a/schema/components.json
+++ b/schema/components.json
@@ -305,8 +305,8 @@
           }
         },
         "motivation": {
-          "Title": "Motivation",
-          "Description": "The motivation for this annotation, chosen from a codelist. Commenting should be used with the description field to add contextual comments to a field or statement. Correcting should be used to indicate that original material has been corrected, using the method in the description field. Identifying should be used when original data has been augmented or processed for the purpose of identifying natural persons or legal entities, using the method in the description field. Linking should be used to provide contextual material that explains the statement or field; URLs to linked material can be provided in the source field. Provenance should be used to identify the source of information at a statement or field level. Transformation should be used to describe how data has in fields has been changed from its original form. The new form MAY be provided in the transformedContent field.",
+          "title": "Motivation",
+          "description": "The motivation for this annotation, chosen from a codelist. Commenting should be used with the description field to add contextual comments to a field or statement. Correcting should be used to indicate that original material has been corrected, using the method in the description field. Identifying should be used when original data has been augmented or processed for the purpose of identifying natural persons or legal entities, using the method in the description field. Linking should be used to provide contextual material that explains the statement or field; URLs to linked material can be provided in the source field. Provenance should be used to identify the source of information at a statement or field level. Transformation should be used to describe how data has in fields has been changed from its original form. The new form MAY be provided in the transformedContent field.",
           "type": "string",
           "enum": ["commenting", "correcting", "identifying", "linking", "transformation"]
         },

--- a/tests/data/bods-package/valid/valid-bods-package-annotations.json
+++ b/tests/data/bods-package/valid/valid-bods-package-annotations.json
@@ -11,21 +11,15 @@
         "id": "06292597"
       }
     ],
-    "annotations": [
-      {
-        "statementPointerTarget": "/",
-        "motivation": "provenance",
-        "source": {
-          "type": ["officialRegister"],
-          "url": "https://beta.companieshouse.gov.uk/company/06292597",
-          "assertedBy": [
-            {
-            "name": "DRILLGREAT LIMITED"
-            }
-          ]
+    "source": {
+      "type": ["officialRegister"],
+      "url": "https://beta.companieshouse.gov.uk/company/06292597",
+      "assertedBy": [
+        {
+        "name": "DRILLGREAT LIMITED"
         }
-      }
-    ]
+      ]
+    }
   },
   {
     "statementID": "cfd1747f-9fbc-461a-af94-710120705b4c",
@@ -40,26 +34,18 @@
         "id": "02585514"
       }
     ],
-    "incorporatedIn": {
-      "jurisdiction": {
-        "code": "GB"
-      }
+    "incorporatedInJurisdiction": {
+      "code": "GB"
     },
-    "annotations": [
-      {
-        "statementPointerTarget": "/",
-        "motivation" : "provenance",
-        "source": {
-          "type": ["officialRegister"],
-          "url": "https://beta.companieshouse.gov.uk/company/02585514/persons-with-significant-control",
-          "assertedBy": [
-            {
-              "name": "MONSOON HOLDINGS (NO.1) LIMITED"
-            }
-          ]
+    "source": {
+      "type": ["officialRegister"],
+      "url": "https://beta.companieshouse.gov.uk/company/02585514/persons-with-significant-control",
+      "assertedBy": [
+        {
+          "name": "MONSOON HOLDINGS (NO.1) LIMITED"
         }
-      }
-    ]
+      ]
+    }
   },
   {
     "statementID": "ac11f4c3-3dc5-499b-acc5-599632187ebd",
@@ -71,32 +57,22 @@
     "interestedParty": {
         "describedByEntityStatement": "78db70df-49cd-47c9-9ee9-2e5539ec7a5f"
     },
-    "annotations": [
-      {
-        "statementPointerTarget": "/",
-        "motivation": "provenance",
-        "source": {
-          "type": ["officialRegister"],
-          "url": "https://beta.companieshouse.gov.uk/company/02585514/persons-with-significant-control",
-          "assertedBy": [
-            {
-              "name": "MONSOON HOLDINGS (NO.1) LIMITED"
-            }
-          ]
+    "source": {
+      "type": ["officialRegister"],
+      "url": "https://beta.companieshouse.gov.uk/company/02585514/persons-with-significant-control",
+      "assertedBy": [
+        {
+          "name": "MONSOON HOLDINGS (NO.1) LIMITED"
         }
-      },
+      ]
+    },
+    "annotations": [
       {
         "statementPointerTarget": "/interestedParty",
         "motivation" : "identifying",
         "description": "Company number missing from benenficial ownership statement. Manually reconciled against official register.",
-        "source": {
-          "type": ["primaryResearch", "officialRegister"],
-          "url": "https://beta.companieshouse.gov.uk/company/06292597",
-          "assertedBy": [
-            {
-              "name": "Jack Lord"
-            }
-          ]
+        "createdBy": {
+          "name": "Jack Lord"
         }
       }
     ]

--- a/tests/data/bods-package/valid/valid-bods-package-linking-annotations.json
+++ b/tests/data/bods-package/valid/valid-bods-package-linking-annotations.json
@@ -11,36 +11,36 @@
         "id": "10970413"
       }
     ],
-    "annotations": [
-      {
-        "statementPointerTarget": "/",
-        "motivation": "provenance",
-        "source": {
-          "type": [
-            "officialRegister"
-          ],
-          "url": "https://beta.companieshouse.gov.uk/company/10970413"
+    "source": {
+      "type": [
+        "officialRegister"
+      ],
+      "url": "https://beta.companieshouse.gov.uk/company/10970413",
+      "assertedBy": [
+        {
+          "name": "MARE POND PROPERTIES LIMITED",
+          "uri": "https://beta.companieshouse.gov.uk/company/10970413"
         }
-      }
-    ]
+      ]
+    }
   },
   {
     "statementID": "9132d890-0658-4e84-b7b6-9f1886225e45",
     "statementType": "personStatement",
     "statementDate": "2018-03-29",
     "name": "Mr Jeremy Hunt",
-    "annotations": [
-      {
-        "statementPointerTarget": "/",
-        "motivation": "provenance",
-        "source": {
-          "type": [
-            "officialRegister"
-          ],
-          "url": "https://beta.companieshouse.gov.uk/company/10970413"
+    "source": {
+      "type": [
+        "officialRegister"
+      ],
+      "url": "https://beta.companieshouse.gov.uk/company/10970413",
+      "assertedBy": [
+        {
+          "name": "MARE POND PROPERTIES LIMITED",
+          "uri": "https://beta.companieshouse.gov.uk/company/10970413"
         }
-      }
-    ]
+      ]
+    }
   },
   {
     "statementID": "6bf33a35-4c3a-40a9-b5d6-bc3e20b4b39a",
@@ -67,16 +67,6 @@
     ],
     "annotations": [
       {
-        "statementPointerTarget": "/",
-        "motivation": "provenance",
-        "source": {
-          "type": [
-            "officialRegister"
-          ],
-          "url": "https://beta.companieshouse.gov.uk/company/10970413"
-        }
-      },
-      {
         "statementPointerTarget": "/interestedParty/person",
         "motivation": "commenting",
         "description": "The interested party is a British MP and, at the time this statement was made, the Secretary of State for Health and Social Care."
@@ -84,14 +74,21 @@
       {
         "statementPointerTarget": "/interests/0",
         "motivation": "linking",
-        "source": {
-          "type": [
-            "thirdParty"
-          ],
-          "url": "https://www.theyworkforyou.com/regmem/?p=11859",
-          "description": "Register of Members' Interests. The interest in Mare Pond Properties Limited was declared retroactively in both the UK PSC register and the linked Register of Members' Interests following press reports."
-        }
+        "description": "Register of Members' Interests. The interest in Mare Pond Properties Limited was declared retroactively in both the UK PSC register and the linked Register of Members' Interests following press reports.",
+        "url": "https://www.theyworkforyou.com/regmem/?p=11859"
       }
-    ]
+    ],
+    "source":{
+      "type": [
+        "officialRegister"
+      ],
+      "url": "https://beta.companieshouse.gov.uk/company/10970413",
+      "assertedBy": [
+        {
+          "name": "MARE POND PROPERTIES LIMITED",
+          "uri": "https://beta.companieshouse.gov.uk/company/10970413"
+        }
+      ]
+    }
   }
 ]

--- a/tests/data/entity-statement/valid/valid-entity-statement-transliteration-annotations.json
+++ b/tests/data/entity-statement/valid/valid-entity-statement-transliteration-annotations.json
@@ -26,15 +26,11 @@
       "motivation": "transformation",
       "description": "Transliterated from Ukranian to Latin characters using...",
       "transformedContent": "T01021, m.Kyyiv, Pechersʹkyy rayon, VULYTSYA M.HRUSHEVSʹKOHO, budynok 28/2, nezhyle prymishchennya 43"
-    },
-    {
-      "statementPointerTarget": "/",
-      "motivation": "provenance",
-      "source": {
-        "type": ["officialRegister", "thirdParty"],
-        "description": "Open Ownership Register, using data from the Ukraine United State Register and OpenCorporates",
-        "url": "https://register.openownership.org/entities/5a7b038b9dfc3fae18417a58?transliterated=true"
-      }
     }
-  ]
+  ],
+  "source": {
+    "type": ["officialRegister", "thirdParty"],
+    "description": "Open Ownership Register, using data from the Ukraine United State Register and OpenCorporates",
+    "url": "https://register.openownership.org/entities/5a7b038b9dfc3fae18417a58?transliterated=true"
+  }
 }


### PR DESCRIPTION
This PR:

- Removes `provenance` as a type of annotation, following removal of source from annotation.
- Adds a `url` field for annotations with type `linking`. This replaces the array of `Source` objects.
- Changes `createdBy` to a single object (with name and uri) rather than an array of `Agent` objects.  