### PR TITLE
Fixing inconsistencies on replacesStatements

### DIFF
--- a/docs/schema/guidance/updating-data.rst
+++ b/docs/schema/guidance/updating-data.rst
@@ -5,9 +5,9 @@ Updating statements
 
 Statements MUST be treated as immutable: once a statement is published it MUST NOT be republished with the same ``statementID`` and different property values. 
 
-If a particular value needs to be updated, a new statement with a new ``statementID`` MUST be published and the ``replacesStatement`` property used. 
+If a particular value needs to be updated, a new statement with a new ``statementID`` MUST be published and the ``replacesStatements`` property used to indicate the statement that is no longer true. 
 
-The ``replacesStatements`` property can be used to indicate that one statement should be considered as a replacement for a previous statement.
+The ``replacesStatements`` property can be used to indicate that one statement should be considered as a replacement for one or more previous statements.
 
 
 


### PR DESCRIPTION
The guidance was inconsistent in it's reference to `replacesStatement` vs `replacesStatements` and the language suggesting that only one previous statement could be referred to.

I've fixed this. As guidance was previously outside of the normative parts of the documentation, I believe this fix should be possible as a 'typo' fix within the layout updates to schema-beta-2.