### PR TITLE
Closes #124 datetime format typo

### DIFF
--- a/schema/components.json
+++ b/schema/components.json
@@ -45,7 +45,7 @@
           "title": "Retrieved at",
           "description": "If this statement was imported from some external system, include a timestamp indicating when this took place. The statement's own date should be set based on the source information. ",
           "type": "string",
-          "format": "datetime"
+          "format": "date-time"
         },
         "assertedBy": {
           "title": "Asserted by",

--- a/tests/data/entity-statement/invalid/entity-statement-invalid-date-in-source.json
+++ b/tests/data/entity-statement/invalid/entity-statement-invalid-date-in-source.json
@@ -1,0 +1,28 @@
+{
+  "statementID": "323591c5-2093-4716-8494-c5573c7452e6",
+  "statementType": "entityStatement",
+  "statementDate": "2018-11-14",
+  "entityType": "registeredEntity",
+  "name": "OPEN DATA SERVICES CO-OPERATIVE LIMITED",
+  "foundingDate": "2015-04-24",
+  "identifiers": [
+    {
+      "scheme": "GB-COH",
+      "id": "09506232"
+    }
+  ],
+  "incorporatedInJurisdiction": {
+    "code": "GB"
+  },
+  "source": {
+    "type": ["officialRegister"],
+    "description": "Companies House, United Kingdom",
+    "url": "https://beta.companieshouse.gov.uk/company/09506232",
+    "assertedBy": [
+      {
+      "name": "OPEN DATA SERVICES CO-OPERATIVE LIMITED"
+      }
+    ],
+    "retrievedAt": "2018-11-14"
+  }
+}

--- a/tests/data/entity-statement/valid/valid-entity-statement-with-source.json
+++ b/tests/data/entity-statement/valid/valid-entity-statement-with-source.json
@@ -1,0 +1,28 @@
+{
+  "statementID": "323591c5-2093-4716-8494-c5573c7452e6",
+  "statementType": "entityStatement",
+  "statementDate": "2018-11-14",
+  "entityType": "registeredEntity",
+  "name": "OPEN DATA SERVICES CO-OPERATIVE LIMITED",
+  "foundingDate": "2015-04-24",
+  "identifiers": [
+    {
+      "scheme": "GB-COH",
+      "id": "09506232"
+    }
+  ],
+  "incorporatedInJurisdiction": {
+    "code": "GB"
+  },
+  "source": {
+    "type": ["officialRegister"],
+    "description": "Companies House, United Kingdom",
+    "url": "https://beta.companieshouse.gov.uk/company/09506232",
+    "assertedBy": [
+      {
+      "name": "OPEN DATA SERVICES CO-OPERATIVE LIMITED"
+      }
+    ],
+    "retrievedAt": "2018-11-14T17:23:43.977Z"
+  }
+}

--- a/tests/test_data.py
+++ b/tests/test_data.py
@@ -13,6 +13,7 @@ from bods_validate import bods_iter_errors_package, bods_iter_errors_statement
 @pytest.mark.parametrize('json_path', [
     'data/entity-statement/valid/valid-entity-statement.json',
     'data/entity-statement/valid/valid-entity-statement-loose-validation.json',
+    'data/entity-statement/valid/valid-entity-statement-with-source.json',
     'data/person-statement/valid/valid-person-statement.json',
     'data/ownership-or-control-statement/valid/valid-ownership-or-control-statement.json',
     '../examples/flat-serialisation/gb-coh-entity-statement.json',
@@ -58,6 +59,7 @@ def test_valid_package_json(json_path):
     ('data/entity-statement/invalid/entity-statement-with-invalid-statement-id.json', ValidationError),
     ('data/entity-statement/invalid/entity-statement-with-invalid-statement-id-no-entity-type.json', ValidationError),
     ('data/entity-statement/invalid/entity-statement-extra-field.json', ValidationError),
+    ('data/entity-statement/invalid/entity-statement-invalid-date-in-source.json', ValidationError),
     ('data/person-statement/invalid/person-statement-with-invalid-statement-id.json', ValidationError),
     ('data/person-statement/invalid/person-statement-with-bad-date.json', ValidationError),
     ('data/ownership-or-control-statement/invalid/ownership-or-control-statement-with-invalid-statement-id.json', ValidationError),
@@ -128,6 +130,9 @@ def test_invalid_package_json(json_path, json_paths, error):
     }),
     ('data/person-statement/invalid/person-statement-with-bad-date.json', {
         "'Tuesday' is not a 'date'",
+    }),
+    ('data/entity-statement/invalid/entity-statement-invalid-date-in-source.json', {
+        "'2018-11-14' is not a 'date-time'",
     }),
     ('data/ownership-or-control-statement/invalid/ownership-or-control-statement-with-invalid-statement-id.json', {
         "'too-short-so-fail' is too short",


### PR DESCRIPTION
Context for this PR is that OO's validation (using a Ruby library) didn't work unless the format `datetime` in a `Source`'s `retrievedAt` field was changed to `date-time`. The intention of this is to be used as a timestamp, so I think we can switch this over. There might be a use-case for a fuzzy date in some contexts where data is being produced at human-scale - but we can address in subsequent release, I think?

First commit adds some test data and tests - the Python validation library doesn't throw an error on encountering the unknown 'datetime' format. But it also doesn't perform any extra validation, so will accept any string as a `datetime`. This is not what we want (but we do want the build to fail, as it does here).

Second commit changes the schema and the tests throw the expected errors.  