### PR TITLE
0.1 release - docs update

### DIFF
--- a/docs/about/credits.md
+++ b/docs/about/credits.md
@@ -1,7 +1,7 @@
 Credits
 =======
 
-The first beta version of the Beneficial Ownership Data Standard was written by Tim Davies ([Open Data Services Co-operative](http://www.opendataservices.coop)) with Ben Symonds ([OpenCorporates](http://www.opencorporates.com)), Chris Taggart ([OpenCorporates](http://www.opencorporates.com)) and Jack Lord ([Knowcale](http://knocale.com)) and supported by the [data standard working group](governance.md).
+The first beta version of the Beneficial Ownership Data Standard was written by Tim Davies ([Open Data Services Co-operative](http://www.opendataservices.coop)) with Ben Symonds ([OpenCorporates](http://www.opencorporates.com)), Chris Taggart ([OpenCorporates](http://www.opencorporates.com)) and Jack Lord ([Open Data Services Co-operative](http://www.opendataservices.coop)) and supported by the [data standard working group](governance.md).
 
-The second beta version was written by Tim Davies and Jack Lord with supporting documentation from Kadie Armstrong ([Open Data Services Co-operative](http://www.opendataservices.coop)), technical work from James Baster ([Open Data Services Co-operative](http://www.opendataservices.coop)) and input from the [data standard working group](governance.md).
+The 0.1 version was written by Tim Davies and Jack Lord with supporting documentation from Kadie Armstrong ([Open Data Services Co-operative](http://www.opendataservices.coop)), technical work from James Baster ([Open Data Services Co-operative](http://www.opendataservices.coop)) and input from the [data standard working group](governance.md).
 

--- a/docs/about/index.md
+++ b/docs/about/index.md
@@ -19,7 +19,7 @@ The Standard is being developed under the guidance of a [working group](governan
    :alt: Timeline of standard development. End of 2016: rapid prototype. 2017, Q2: release of BODS Beta-1. 2017, Q3: initital pilots. 2018, Q3: release of BODS Beta-2. 2019: release of BODS v1.0.
 
 ```
-This is v0.1 (release candidate) of the Beneficial Ownership Data Standard. The data model has been updated and additional codelist information added since Beta-1.
+This is v0.1 of the Beneficial Ownership Data Standard. The data model has been updated and additional codelist information added since Beta-1.
 
 Implementers should be aware that future changes are anticipated, before a version 1.0 release. However, from this v0.1 release onwards, any structural changes or major definitional changes will only take place following consultation. A clear [changelog](changelog) will be provided, and the documentation of previous versions maintained in archive form.
 

--- a/docs/about/index.md
+++ b/docs/about/index.md
@@ -19,7 +19,7 @@ The Standard is being developed under the guidance of a [working group](governan
    :alt: Timeline of standard development. End of 2016: rapid prototype. 2017, Q2: release of BODS Beta-1. 2017, Q3: initital pilots. 2018, Q3: release of BODS Beta-2. 2019: release of BODS v1.0.
 
 ```
-This is v0.1-rc (release candidate) of the Beneficial Ownership Data Standard. The data model has been updated and additional codelist information added since Beta-1.
+This is v0.1 (release candidate) of the Beneficial Ownership Data Standard. The data model has been updated and additional codelist information added since Beta-1.
 
 Implementers should be aware that future changes are anticipated, before a version 1.0 release. However, from this v0.1 release onwards, any structural changes or major definitional changes will only take place following consultation. A clear [changelog](changelog) will be provided, and the documentation of previous versions maintained in archive form.
 

--- a/docs/conf.py
+++ b/docs/conf.py
@@ -54,7 +54,7 @@ source_suffix = ['.rst', '.md']
 master_doc = 'index'
 
 # General information about the project.
-project = 'Beneficial Ownership Data Standard (beta)'
+project = 'Beneficial Ownership Data Standard'
 copyright = '2017, OpenOwnership'
 author = 'OpenOwnership'
 

--- a/docs/index.rst
+++ b/docs/index.rst
@@ -1,4 +1,4 @@
-Beneficial Ownership Data Standard (v0.1-rc)
+Beneficial Ownership Data Standard (v0.1)
 ============================================
 
 This website contains the draft specification of the Beneficial Ownership Data Standard (0.1 version - release candidate) plus support for its use. :doc:`Find out more <about/index>` about the standard's development and how to get involved.

--- a/docs/schema/changelog.rst
+++ b/docs/schema/changelog.rst
@@ -6,7 +6,7 @@ ChangeLog
 
 .. attention:: 
    
-    This is v0.1-rc (release candidate) of the Beneficial Ownership Data Standard. It includes updates to the data model and additional codelist information.
+    This is v0.1 (release candidate) of the Beneficial Ownership Data Standard. It includes updates to the data model and additional codelist information.
 
     Implementers should be aware that future changes are anticipated, before a version 1.0 release. However, from this v0.1 release onwards, any structural changes, or major definitional changes will only take place following consultation, with a clear changelog provided, and with the documentation of previous versions maintained in archive form.
 

--- a/docs/schema/changelog.rst
+++ b/docs/schema/changelog.rst
@@ -6,7 +6,7 @@ ChangeLog
 
 .. attention:: 
    
-    This is v0.1 (release candidate) of the Beneficial Ownership Data Standard. It includes updates to the data model and additional codelist information.
+    This is v0.1 of the Beneficial Ownership Data Standard. It includes updates to the data model and additional codelist information.
 
     Implementers should be aware that future changes are anticipated, before a version 1.0 release. However, from this v0.1 release onwards, any structural changes, or major definitional changes will only take place following consultation, with a clear changelog provided, and with the documentation of previous versions maintained in archive form.
 

--- a/docs/schema/concepts.rst
+++ b/docs/schema/concepts.rst
@@ -5,7 +5,7 @@ Key concepts
 
 .. attention:: 
     
-    This is v0.1 (release candidate) of the Beneficial Ownership Data Standard. It includes updates to the data model and additional codelist information. Implementers should be aware that future changes are anticipated, before a version 1.0 release. See the :doc:`Changelog <changelog>` and `About <../about>`_ pages for more information.
+    This is v0.1 of the Beneficial Ownership Data Standard. It includes updates to the data model and additional codelist information. Implementers should be aware that future changes are anticipated, before a version 1.0 release. See the :doc:`Changelog <changelog>` and `About <../about>`_ pages for more information.
 
     **MUST** and **SHOULD** are used in the schema to denote required and recommended elements of the Standard, as defined in `RFC2119 <https://tools.ietf.org/html/rfc2119>`_.
 

--- a/docs/schema/concepts.rst
+++ b/docs/schema/concepts.rst
@@ -5,7 +5,7 @@ Key concepts
 
 .. attention:: 
     
-    This is v0.1-rc (release candidate) of the Beneficial Ownership Data Standard. It includes updates to the data model and additional codelist information. Implementers should be aware that future changes are anticipated, before a version 1.0 release. See the :doc:`Changelog <changelog>` and `About <../about>`_ pages for more information.
+    This is v0.1 (release candidate) of the Beneficial Ownership Data Standard. It includes updates to the data model and additional codelist information. Implementers should be aware that future changes are anticipated, before a version 1.0 release. See the :doc:`Changelog <changelog>` and `About <../about>`_ pages for more information.
 
     **MUST** and **SHOULD** are used in the schema to denote required and recommended elements of the Standard, as defined in `RFC2119 <https://tools.ietf.org/html/rfc2119>`_.
 

--- a/docs/schema/conformance.rst
+++ b/docs/schema/conformance.rst
@@ -22,6 +22,6 @@ Publishers providing additional properties in their implementations are encourag
 Validation
 ----------
 
-No public validator available for the v0.1 release is currently available.
+No public validator for the v0.1 release is currently available.
 
 The current schema includes minimal validation requirements, and should be treated as a guide to data structure, rather than a full validation schema. 

--- a/docs/schema/guidance/index.rst
+++ b/docs/schema/guidance/index.rst
@@ -3,7 +3,7 @@ Technical guidance
 
 .. attention:: 
     
-    This is v0.1-rc (release candidate) of the Beneficial Ownership Data Standard. It includes updates to the data model and additional codelist information. Implementers should be aware that future changes are anticipated, before a version 1.0 release. See the :any:`Changelog <changelog>` and `About <../about>`_ pages for more information.
+    This is v0.1 (release candidate) of the Beneficial Ownership Data Standard. It includes updates to the data model and additional codelist information. Implementers should be aware that future changes are anticipated, before a version 1.0 release. See the :any:`Changelog <changelog>` and `About <../about>`_ pages for more information.
 
     **MUST** and **SHOULD** are used in the schema to denote required and recommended elements of the Standard, as defined in `RFC2119 <https://tools.ietf.org/html/rfc2119>`_.
 

--- a/docs/schema/guidance/index.rst
+++ b/docs/schema/guidance/index.rst
@@ -3,7 +3,7 @@ Technical guidance
 
 .. attention:: 
     
-    This is v0.1 (release candidate) of the Beneficial Ownership Data Standard. It includes updates to the data model and additional codelist information. Implementers should be aware that future changes are anticipated, before a version 1.0 release. See the :any:`Changelog <changelog>` and `About <../about>`_ pages for more information.
+    This is v0.1 of the Beneficial Ownership Data Standard. It includes updates to the data model and additional codelist information. Implementers should be aware that future changes are anticipated, before a version 1.0 release. See the :any:`Changelog <changelog>` and `About <../about>`_ pages for more information.
 
     **MUST** and **SHOULD** are used in the schema to denote required and recommended elements of the Standard, as defined in `RFC2119 <https://tools.ietf.org/html/rfc2119>`_.
 

--- a/docs/schema/index.rst
+++ b/docs/schema/index.rst
@@ -3,7 +3,7 @@ Data Schema
 
 .. attention:: 
     
-    This is v0.1-rc (release candidate) of the Beneficial Ownership Data Standard. It includes updates to the data model and additional codelist information. Implementers should be aware that future changes are anticipated, before a version 1.0 release. See the :doc:`Changelog <changelog>` and `About <../about>`_ pages for more information.
+    This is v0.1 (release candidate) of the Beneficial Ownership Data Standard. It includes updates to the data model and additional codelist information. Implementers should be aware that future changes are anticipated, before a version 1.0 release. See the :doc:`Changelog <changelog>` and `About <../about>`_ pages for more information.
 
     **MUST** and **SHOULD** are used in the schema to denote required and recommended elements of the Standard, as defined in `RFC2119 <https://tools.ietf.org/html/rfc2119>`_.
 

--- a/docs/schema/index.rst
+++ b/docs/schema/index.rst
@@ -3,7 +3,7 @@ Data Schema
 
 .. attention:: 
     
-    This is v0.1 (release candidate) of the Beneficial Ownership Data Standard. It includes updates to the data model and additional codelist information. Implementers should be aware that future changes are anticipated, before a version 1.0 release. See the :doc:`Changelog <changelog>` and `About <../about>`_ pages for more information.
+    This is v0.1 of the Beneficial Ownership Data Standard. It includes updates to the data model and additional codelist information. Implementers should be aware that future changes are anticipated, before a version 1.0 release. See the :doc:`Changelog <changelog>` and `About <../about>`_ pages for more information.
 
     **MUST** and **SHOULD** are used in the schema to denote required and recommended elements of the Standard, as defined in `RFC2119 <https://tools.ietf.org/html/rfc2119>`_.
 

--- a/docs/schema/reference.rst
+++ b/docs/schema/reference.rst
@@ -5,7 +5,7 @@ Schema reference
 
 .. attention:: 
     
-    This is v0.1 (release candidate) of the Beneficial Ownership Data Standard. It includes updates to the data model and additional codelist information. Implementers should be aware that future changes are anticipated, before a version 1.0 release. See the :doc:`Changelog <changelog>` and `About <../about>`_ pages for more information.
+    This is v0.1 of the Beneficial Ownership Data Standard. It includes updates to the data model and additional codelist information. Implementers should be aware that future changes are anticipated, before a version 1.0 release. See the :doc:`Changelog <changelog>` and `About <../about>`_ pages for more information.
 
     **MUST** and **SHOULD** are used in the schema to denote required and recommended elements of the Standard, as defined in `RFC2119 <https://tools.ietf.org/html/rfc2119>`_.
 

--- a/docs/schema/reference.rst
+++ b/docs/schema/reference.rst
@@ -5,7 +5,7 @@ Schema reference
 
 .. attention:: 
     
-    This is v0.1-rc (release candidate) of the Beneficial Ownership Data Standard. It includes updates to the data model and additional codelist information. Implementers should be aware that future changes are anticipated, before a version 1.0 release. See the :doc:`Changelog <changelog>` and `About <../about>`_ pages for more information.
+    This is v0.1 (release candidate) of the Beneficial Ownership Data Standard. It includes updates to the data model and additional codelist information. Implementers should be aware that future changes are anticipated, before a version 1.0 release. See the :doc:`Changelog <changelog>` and `About <../about>`_ pages for more information.
 
     **MUST** and **SHOULD** are used in the schema to denote required and recommended elements of the Standard, as defined in `RFC2119 <https://tools.ietf.org/html/rfc2119>`_.
 

--- a/docs/schema/schema-browser.rst
+++ b/docs/schema/schema-browser.rst
@@ -5,7 +5,7 @@ Schema browser
 
 .. attention:: 
     
-    This is v0.1 (release candidate) of the Beneficial Ownership Data Standard. It includes updates to the data model and additional codelist information. Implementers should be aware that future changes are anticipated, before a version 1.0 release. See the :doc:`Changelog <changelog>` and `About <../about>`_ pages for more information.
+    This is v0.1 of the Beneficial Ownership Data Standard. It includes updates to the data model and additional codelist information. Implementers should be aware that future changes are anticipated, before a version 1.0 release. See the :doc:`Changelog <changelog>` and `About <../about>`_ pages for more information.
 
     **MUST** and **SHOULD** are used in the schema to denote required and recommended elements of the Standard, as defined in `RFC2119 <https://tools.ietf.org/html/rfc2119>`_.
 

--- a/docs/schema/schema-browser.rst
+++ b/docs/schema/schema-browser.rst
@@ -5,7 +5,7 @@ Schema browser
 
 .. attention:: 
     
-    This is v0.1-rc (release candidate) of the Beneficial Ownership Data Standard. It includes updates to the data model and additional codelist information. Implementers should be aware that future changes are anticipated, before a version 1.0 release. See the :doc:`Changelog <changelog>` and `About <../about>`_ pages for more information.
+    This is v0.1 (release candidate) of the Beneficial Ownership Data Standard. It includes updates to the data model and additional codelist information. Implementers should be aware that future changes are anticipated, before a version 1.0 release. See the :doc:`Changelog <changelog>` and `About <../about>`_ pages for more information.
 
     **MUST** and **SHOULD** are used in the schema to denote required and recommended elements of the Standard, as defined in `RFC2119 <https://tools.ietf.org/html/rfc2119>`_.
 

--- a/schema/bods-package.json
+++ b/schema/bods-package.json
@@ -1,7 +1,7 @@
 {
   "id": "bods-package.json",
   "$schema": "http://json-schema.org/draft-04/schema#",
-  "version": "0.1-rc",
+  "version": "0.1",
   "type": "array",
   "items": {
     "oneOf": [

--- a/schema/components.json
+++ b/schema/components.json
@@ -1,7 +1,7 @@
 {
   "id": "components.json",
   "$schema": "http://json-schema.org/draft-04/schema#",
-  "version": "0.1-rc",
+  "version": "0.1",
   "definitions": {
     "StatementDate": {
       "title": "Statement date",

--- a/schema/entity-statement.json
+++ b/schema/entity-statement.json
@@ -1,7 +1,7 @@
 {
   "id": "entity-statement.json",
   "$schema": "http://json-schema.org/draft-04/schema#",
-  "version": "0.1-rc",
+  "version": "0.1",
   "title": "Entity statement",
   "description": "A statement identifying and describing the entity that is the subject of the ownership or control described in an ownership or control statement.",
   "type": "object",

--- a/schema/ownership-or-control-statement.json
+++ b/schema/ownership-or-control-statement.json
@@ -1,7 +1,7 @@
 {
   "id": "ownership-or-control-statement.json",
   "$schema": "http://json-schema.org/draft-04/schema#",
-  "version": "0.1-rc",
+  "version": "0.1",
   "title": "Ownership or control Statement",
   "description": "An ownership or control statement is made up of an entity, an interested party (a reference to an entity, natural person, arrangement or trust), details of the interest and provenance information for the statement.",
   "type": "object",

--- a/schema/person-statement.json
+++ b/schema/person-statement.json
@@ -1,7 +1,7 @@
 {
   "id": "person-statement.json",
   "$schema": "http://json-schema.org/draft-04/schema#",
-  "version": "0.1-rc",
+  "version": "0.1",
   "type": "object",
   "title": "Person statement",
   "description": "A person statement describes the information known about a natural person at a particular point in time, or from a given submission of information",


### PR DESCRIPTION
This removes references to 'beta', 'release candidate' and 'rc' in the docs.