### PR TITLE
Improved Identifier guidance re schemeName - fixes #159

### DIFF
--- a/docs/schema/guidance/identifiers.rst
+++ b/docs/schema/guidance/identifiers.rst
@@ -3,20 +3,28 @@
 Real world identifiers
 =============================
 
-To create a link between statements, and the real-world organisations and people they relate to, statements may include a range of identifying information. We use a common identifier object, with two required properties, and one optional property.
+To create a link between statements, and the real-world organisations and people they relate to, statements may include a range of identifying information. We use a common :any:`Identifier object <schema-identifier>` with the following properties:
 
-* **scheme** must be a value from a codelist of known identifier sources. Separate codelists exist for entities and persons. 
+* ``scheme`` should be a value from a codelist of known identifier sources. Separate codelists exist for entities and persons. See below.
 
-* **id** must be the value assigned to the relevant entity or person in that scheme;
+* ``id`` should be the value assigned to the relevant entity or person in that scheme.
 
-  - **uri** may be used to provide a canonical URI from this scheme.
+* ``uri`` may be used to provide a canonical URI for the entity or person within the scheme.
 
-For example, if a source system holds:
+* ``schemeName`` should be the name of the list, registry or ID system.
+
+A good-quality Identifier will contain ``scheme`` and ``id`` values which will uniquely identify an entity or person. Where these are not available, ``schemeName`` can be used to refer to the registration system in which the person or entity is known to be represented. When publishing an Identifier object, a value for either ``scheme`` or ``schemeName`` MUST be present.
+
+
+Multiple Identifiers
+--------------------
+
+A source system might hold the following identifying information for a single company:
 
 - A registered company number; and
 - A VAT number;
 
-for a company, two entries could be created in the ``Entity/identifiers`` array, as in the example below:
+In this case, two entries can be created in the Entity statement's ``identifiers`` array:
 
 .. code-block:: json
 
@@ -31,11 +39,13 @@ for a company, two entries could be created in the ``Entity/identifiers`` array,
         }
     ]
 
+Person Statements may also hold an array of Identifiers.
+
 
 Entity Identifiers
 ------------------
 
-The values for scheme within an entity statement identifier should be drawn from the `http://org-id.guide <http://org-id.guide>`_ codelist. This contains details of 100s of company registers and other identifier sources. 
+The values for ``scheme`` within an Entity Statement Identifier should be drawn from the `http://org-id.guide <http://org-id.guide>`_ codelist. This contains details of hundreds of company registers and other identifier sources. 
 
 Where the publisher is providing an internal identifier, the publisher should either:
 
@@ -46,20 +56,20 @@ Where the publisher is providing an internal identifier, the publisher should ei
 Person Identifiers
 ------------------
 
-System identifiers
+System Identifiers
 ++++++++++++++++++
 
 If the source system has assigned a unique identifier to individual persons, and this identifier can be published, then this should be included with the scheme 'MISC-{Publisher Name}'.
 
-For example, a beneficial ownership reporting system may maintain a database table of 'person' records, each with it's identifier as a primary key. So that users can recognise references to the same person mentioned in separate statements, this identifier should be included in the published data, either in raw form, or modified to ensure a unique value. 
+For example, a beneficial ownership reporting system may maintain a database table of 'person' records, each with its identifier as a primary key. So that users can recognise references to the same person mentioned in separate statements, this identifier should be included in the published data, either in raw form, or modified to ensure a unique value. 
 
 
 Shared identifiers
 ++++++++++++++++++
 
-If the source system has collected one or more known identification numbers for a person, and these can be published without privacy or security risks, then these should also be included in the ``Person/identifiers`` array. 
+If the source system has collected one or more known identification numbers for a person, and these can be published without privacy or security risks, then these should also be included in the ``PersonStatement.identifiers`` array. 
 
-The values for scheme within a person statement should be based on the following pattern:
+In such cases, the values for ``scheme`` should be based on the following pattern:
 
 {JURISDICTION}-{TYPE}
 

--- a/docs/schema/reference.rst
+++ b/docs/schema/reference.rst
@@ -91,7 +91,7 @@ EntityStatement
 Identifier
 ----------
 
-The identifier component is used to connect a statement to the real-world person or entity that it refers to, using one or more existing known identifiers. See [Real world identifiers](identifiers.md) for technical guidance on when and how to use this component.
+The Identifier object is used to connect a statement to the real-world person or entity that it refers to, using one or more existing known identifiers. See :any:`Real world identifiers <guidance-identifiers>` for technical guidance on when and how to use this object.
 
 .. json-value:: ../../schema/components.json
    :pointer: /definitions/Identifier/description
@@ -163,10 +163,10 @@ PEPStatus
 ---------
 
 .. json-value:: ../../schema/components.json
-   :pointer: /definitions/PepStatus/description
+   :pointer: /definitions/PepStatusDetails/description
 
 .. jsonschema:: ../../schema/components.json
-   :pointer: /definitions/PepStatus
+   :pointer: /definitions/PepStatusDetails
    :collapse: jurisdiction
 
 .. _schema-person-statement:

--- a/schema/components.json
+++ b/schema/components.json
@@ -100,12 +100,12 @@
         },
         "scheme": {
           "title": "Scheme",
-          "description": "For entity statements, the scheme should be a entry from the [org-id.guide](http://www.org-id.guide) codelist. For person statements, the scheme should have the pattern {JURISDICTION}-{TYPE} where JURISDICTION is an ISO 3-digit country code and TYPE is one of PASSPORT, TAXID or IDCARD.",
+          "description": "For entity statements, the scheme should be a entry from the [org-id.guide](http://www.org-id.guide) codelist. For person statements, the scheme should have the pattern {JURISDICTION}-{TYPE} where JURISDICTION is an ISO 3-digit country code and TYPE is one of PASSPORT, TAXID or IDCARD. `scheme` or `schemeName` (or both) MUST be included in an Identifier object.",
           "type": "string"
         },
         "schemeName": {
           "title": "Scheme name",
-          "description": "The name of this scheme, where the org-id code is unknown or only an unvalidated string is provided.",
+          "description": "The name of this scheme, where the org-id code is unknown or only an unvalidated string is provided. `scheme` or `schemeName` (or both) MUST be included in an Identifier object.",
           "type": "string"
         },
         "uri": {


### PR DESCRIPTION
Contains an edit to the descriptions for Identifier.scheme and Identifier.schemeName in components.json and improved guidance in the docs. Edits in the docs have also been made for style and readability.

(Was editing with one eye on #159 also, since there may be future changes to make to Identifiers.)