### PR TITLE
add contractual rights, rename rights-to-surplus-assets-on-dissolution

### DIFF
--- a/schema/codelists/interestType.csv
+++ b/schema/codelists/interestType.csv
@@ -9,5 +9,7 @@ trustee-of-trust,Trustee of a trust.
 protector-of-trust,Protector of a trust
 beneficiary-of-trust,Beneficiary of a trust
 other-influence-or-control-of-trust,Other influence or control of a trust
-rights-to-surplus-assets,Rights to surplus assets
+rights-to-surplus-assets-on-dissolution,Rights to surplus assets
 rights-to-profit-or-income,Rights to receive profits or income
+rights-granted-by-contract,Rights granted by contract,The right to use or enjoyment of assets or income granted by contract rather than legal ownership 
+conditional-rights-granted-by-contract,An agreement that defines the conditions under which a beneficial ownership interest would come into existence

--- a/schema/components.json
+++ b/schema/components.json
@@ -243,8 +243,10 @@
             "protector-of-trust",
             "beneficiary-of-trust",
             "other-influence-or-control-of-trust",
-            "rights-to-surplus-assets",
-            "rights-to-profit-or-income"
+            "rights-to-surplus-assets-on-dissolution",
+            "rights-to-profit-or-income",
+            "rights-granted-by-contract",
+            "conditional-rights-granted-by-contract"
           ],
           "codelist": "interestType.csv",
           "openCodelist": false


### PR DESCRIPTION
Adds contractual rights per #10, and renames `rights-to-surplus-assets` to `rights-to-surplus-assets-on-dissolution`, which more closely matches the definition in the UK's PSC register for LLPs.