### PR TITLE
Adds required publicationDetails component to statements - closes #135

### DIFF
--- a/examples/1-single-direct.json
+++ b/examples/1-single-direct.json
@@ -11,7 +11,14 @@
         "scheme": "GB-COH",
         "id": "07444723"
       }
-    ]
+    ],
+    "publicationDetails": {
+        "publicationDate": "2018-02-13",
+        "bodsVersion": "0.2",
+        "publisher": {
+            "name": "CHRINON LTD"
+        }
+    }
   },
   {
     "statementID": "019a93f1-e470-42e9-957b-03559861b2e2",
@@ -43,7 +50,14 @@
         "country": "GB",
         "postCode": "N3 1LF"
       }
-    ]
+    ],
+    "publicationDetails": {
+        "publicationDate": "2018-02-13",
+        "bodsVersion": "0.2",
+        "publisher": {
+            "name": "CHRINON LTD"
+        }
+    }
   },
   {
     "statementID": "fbfd0547-d0c6-4a00-b559-5c5e91c34f5c",
@@ -65,6 +79,13 @@
           "exact": 100
         }
       }
-    ]
+    ],
+    "publicationDetails": {
+        "publicationDate": "2018-02-13",
+        "bodsVersion": "0.2",
+        "publisher": {
+            "name": "CHRINON LTD"
+        }
+    }
   }
 ]

--- a/examples/2-single-update.json
+++ b/examples/2-single-update.json
@@ -11,7 +11,14 @@
         "scheme": "GB-COH",
         "id": "07444723"
       }
-    ]
+    ],
+    "publicationDetails": {
+        "publicationDate": "2018-11-18",
+        "bodsVersion": "0.2",
+        "publisher": {
+            "name": "CHRINON LTD"
+        }
+    }
   },
   {
     "statementID": "019a93f1-e470-42e9-957b-03559861b2e2",
@@ -43,7 +50,14 @@
         "country": "GB",
         "postCode": "N3 1LF"
       }
-    ]
+    ],
+    "publicationDetails": {
+        "publicationDate": "2018-11-18",
+        "bodsVersion": "0.2",
+        "publisher": {
+            "name": "CHRINON LTD"
+        }
+    }
   },
   {
     "statementID": "676ce2ec-e244-409e-85f9-9823e88bc099",
@@ -68,7 +82,14 @@
     ],
     "replacesStatements": [
       "fbfd0547-d0c6-4a00-b559-5c5e91c34f5c"
-    ]
+    ],
+    "publicationDetails": {
+        "publicationDate": "2018-11-18",
+        "bodsVersion": "0.2",
+        "publisher": {
+            "name": "CHRINON LTD"
+        }
+    }
   },
   {
     "statementID": "30e9def3-fa2e-428a-9a02-f43b2a6d5c2e",
@@ -96,6 +117,13 @@
     ],
     "replacesStatements": [
       "fbfd0547-d0c6-4a00-b559-5c5e91c34f5c"
-    ]
+    ],
+    "publicationDetails": {
+        "publicationDate": "2018-11-18",
+        "bodsVersion": "0.2",
+        "publisher": {
+            "name": "CHRINON LTD"
+        }
+    }
   }
 ]

--- a/examples/3-joint-ownership.json
+++ b/examples/3-joint-ownership.json
@@ -22,6 +22,13 @@
     ],
     "incorporatedInJurisdiction": {
       "code": "GB"
+    },
+    "publicationDetails": {
+        "publicationDate": "2018-11-18",
+        "bodsVersion": "0.2",
+        "publisher": {
+            "name": "CHRINON LTD"
+        }
     }
   },
   {
@@ -29,7 +36,14 @@
     "statementType": "entityStatement",
     "statementDate": "2018-01-05",
     "entityType": "arrangement",
-    "name": "Joint shareholding"
+    "name": "Joint shareholding",
+    "publicationDetails": {
+        "publicationDate": "2018-11-18",
+        "bodsVersion": "0.2",
+        "publisher": {
+            "name": "CHRINON LTD"
+        }
+    }
   },
   {
     "statementID": "676ce2ec-e244-409e-85f9-9823e88bc099",
@@ -51,7 +65,14 @@
           "exact": 100
         }
       }
-    ]
+    ],
+    "publicationDetails": {
+        "publicationDate": "2018-11-18",
+        "bodsVersion": "0.2",
+        "publisher": {
+            "name": "CHRINON LTD"
+        }
+    }
   },
   {
     "statementID": "17bfeb0d-4a63-41d3-814d-b8a54c81a1f",
@@ -61,7 +82,14 @@
       {
         "fullName": "Natalie Coleman"
       }
-    ]
+    ],
+    "publicationDetails": {
+        "publicationDate": "2018-11-18",
+        "bodsVersion": "0.2",
+        "publisher": {
+            "name": "CHRINON LTD"
+        }
+    }
   },
   {
     "statementID": "d1eb52de-ff02-4690-8359-f4bbf9c128b1",
@@ -71,7 +99,14 @@
       {
         "fullName": "Roberto López"
       }
-    ]
+    ],
+    "publicationDetails": {
+        "publicationDate": "2018-11-18",
+        "bodsVersion": "0.2",
+        "publisher": {
+            "name": "CHRINON LTD"
+        }
+    }
   },
   {
     "statementID": "c222fe05-2bf3-4cc0-b126-f665109d7211",
@@ -93,7 +128,14 @@
           "exact": 50
         }
       }
-    ]
+    ],
+    "publicationDetails": {
+        "publicationDate": "2018-11-18",
+        "bodsVersion": "0.2",
+        "publisher": {
+            "name": "CHRINON LTD"
+        }
+    }
   },
   {
     "statementID": "c222fe05-2bf3-4cc0-b126-f665109d7211",
@@ -115,6 +157,13 @@
           "exact": 50
         }
       }
-    ]
+    ],
+    "publicationDetails": {
+        "publicationDate": "2018-11-18",
+        "bodsVersion": "0.2",
+        "publisher": {
+            "name": "CHRINON LTD"
+        }
+    }
   }
 ]

--- a/examples/4a-simple-pep-declaration.json
+++ b/examples/4a-simple-pep-declaration.json
@@ -9,7 +9,15 @@
                 "scheme": "GB-COH",
                 "id": "XE-000079054"
             }
-        ]
+        ],
+        "publicationDetails": {
+            "publicationDate": "2019-06-07",
+            "bodsVersion": "0.2",
+            "license": "https://example.com/document/ei-open-data-policy-2015",
+            "publisher": {
+                "name": "ETI International"
+            }
+        }
     },
     {
         "statementID": "a40f766e-0c33-4e34-b9d4-80e39aa99496",
@@ -19,7 +27,15 @@
                 "fullName": "Michael Hubbard"
             }
         ],
-        "hasPepStatus": true
+        "hasPepStatus": true,
+        "publicationDetails": {
+            "publicationDate": "2019-06-07",
+            "bodsVersion": "0.2",
+            "license": "https://example.com/document/ei-open-data-policy-2015",
+            "publisher": {
+                "name": "ETI International"
+            }
+        }
     },
     {
         "statementID": "ef7e0d77-1e2b-44c0-a91c-7670db09d2a4",
@@ -51,6 +67,14 @@
                 "startDate": "2016-07-07",
                 "beneficialOwnershipOrControl": true
             }
-        ]
+        ],
+        "publicationDetails": {
+            "publicationDate": "2019-06-07",
+            "bodsVersion": "0.2",
+            "license": "https://example.com/document/ei-open-data-policy-2015",
+            "publisher": {
+                "name": "ETI International"
+            }
+        }
     }
 ]

--- a/examples/4b-full-pep-declaration.json
+++ b/examples/4b-full-pep-declaration.json
@@ -10,7 +10,15 @@
                 "scheme": "GB-COH",
                 "id": "XE-000079054"
             }
-        ]
+        ],
+      "publicationDetails": {
+          "publicationDate": "2019-06-07",
+          "bodsVersion": "0.2",
+          "license": "https://example.com/document/ei-open-data-policy-2015",
+          "publisher": {
+              "name": "ETI International"
+          }
+      }
     },
     {
         "statementID": "a5680770-899f-4f7a-b795-e266f1ce8668",
@@ -39,7 +47,15 @@
                     ]
                 }
             }
-        ]
+        ],
+        "publicationDetails": {
+            "publicationDate": "2019-06-07",
+            "bodsVersion": "0.2",
+            "license": "https://example.com/document/ei-open-data-policy-2015",
+            "publisher": {
+                "name": "ETI International"
+            }
+        }
     },
     {
         "statementID": "106271aa-10ff-48ad-a5ba-f3f8132b59ff",
@@ -72,6 +88,14 @@
                 "startDate": "2016-07-07",
                 "beneficialOwnershipOrControl": true
             }
-        ]
+        ],
+        "publicationDetails": {
+            "publicationDate": "2019-06-07",
+            "bodsVersion": "0.2",
+            "license": "https://example.com/document/ei-open-data-policy-2015",
+            "publisher": {
+                "name": "ETI International"
+            }
+        }
     }
 ]

--- a/examples/flat-serialisation/gb-coh-bods-package.json
+++ b/examples/flat-serialisation/gb-coh-bods-package.json
@@ -11,7 +11,14 @@
         "scheme": "GB-COH",
         "id": "07444723"
       }
-    ]
+    ],
+    "publicationDetails": {
+      "publicationDate": "2017-11-18",
+      "bodsVersion": "0.2",
+      "publisher": {
+        "name": "CHRINON LTD"
+      }
+    }
   },
   {
     "statementID": "019a93f1-e470-42e9-957b-03559861b2e2",
@@ -43,7 +50,14 @@
         "country": "GB",
         "postCode": "N3 1LF"
       }
-    ]
+    ],
+    "publicationDetails": {
+      "publicationDate": "2017-11-18",
+      "bodsVersion": "0.2",
+      "publisher": {
+        "name": "CHRINON LTD"
+      }
+    }
   },
   {
     "statementID": "fbfd0547-d0c6-4a00-b559-5c5e91c34f5c",
@@ -64,6 +78,13 @@
           "exact": 100
         }
       }
-    ]
+    ],
+    "publicationDetails": {
+      "publicationDate": "2017-11-18",
+      "bodsVersion": "0.2",
+      "publisher": {
+        "name": "CHRINON LTD"
+      }
+    }
   }
 ]

--- a/examples/flat-serialisation/gb-coh-entity-statement.json
+++ b/examples/flat-serialisation/gb-coh-entity-statement.json
@@ -10,5 +10,12 @@
       "scheme": "GB-COH",
       "id": "07444723"
     }
-  ]
+  ],
+  "publicationDetails": {
+    "publicationDate": "2017-11-18",
+    "bodsVersion": "0.2",
+    "publisher": {
+      "name": "CHRINON LTD"
+    }
+  }
 }

--- a/examples/flat-serialisation/gb-coh-person-statement.json
+++ b/examples/flat-serialisation/gb-coh-person-statement.json
@@ -28,5 +28,12 @@
       "country": "GB",
       "postCode": "N3 1LF"
     }
-  ]
+  ],
+  "publicationDetails": {
+    "publicationDate": "2017-11-18",
+    "bodsVersion": "0.2",
+    "publisher": {
+      "name": "CHRINON LTD"
+    }
+  }
 }

--- a/examples/os-01-dr-01.json
+++ b/examples/os-01-dr-01.json
@@ -11,7 +11,16 @@
         "scheme": "GB-COH",
         "id": "XE-A-01"
       }
-    ]
+    ],
+    "publicationDetails": {
+      "publicationDate": "2019-05-15",
+      "bodsVersion": "0.2",
+      "license": "https://opendatacommons.org/licenses/pddl/1.0/",
+      "publisher": {
+        "name": "A. Aygun",
+        "url": "http://www.aaygun.com/real-owners-project"
+      }
+    }
   },
   {
     "statementID": "60f05827-bbb0-4397-9dbd-5031dd3e49d9",
@@ -47,7 +56,16 @@
         "country": "GB",
         "postCode": "SE16 2WN"
       }
-    ]
+    ],
+    "publicationDetails": {
+      "publicationDate": "2019-05-15",
+      "bodsVersion": "0.2",
+      "license": "https://opendatacommons.org/licenses/pddl/1.0/",
+      "publisher": {
+        "name": "A. Aygun",
+        "url": "http://www.aaygun.com/real-owners-project"
+      }
+    }
   },
   {
     "statementID": "069675f7-d44b-4c52-b9c3-c9e4f160228e",
@@ -71,6 +89,15 @@
           "maximum": 100
         }
       }
-    ]
+    ],
+    "publicationDetails": {
+      "publicationDate": "2019-05-15",
+      "bodsVersion": "0.2",
+      "license": "https://opendatacommons.org/licenses/pddl/1.0/",
+      "publisher": {
+        "name": "A. Aygun",
+        "url": "http://www.aaygun.com/real-owners-project"
+      }
+    }
   }
 ]

--- a/examples/workshop/modelling-bods-data/bods-package-ren-consulting-limited.json
+++ b/examples/workshop/modelling-bods-data/bods-package-ren-consulting-limited.json
@@ -1,6 +1,7 @@
 [
   {
     "statementID": "3ff64336-9d26-49da-b0ce-f4685c6af139",
+    "statementDate": "2017-12-01",
     "statementType": "entityStatement",
     "entityType": "registeredEntity",
     "name": "REN Consulting Limited",
@@ -9,19 +10,35 @@
         "scheme": "XE-KS-SRC",
         "id": "93821344"
       }
-    ]
+    ],
+    "publicationDetails": {
+      "publicationDate": "2017-12-01",
+      "bodsVersion": "0.2",
+      "publisher": {
+        "name": "XXXXXXXXX"
+      }
+    }
   },
   {
     "statementID": "5eb1e15c-fd25-40c7-8a75-246c79654185",
+    "statementDate": "2017-12-01",
     "statementType": "personStatement",
     "names": [
       {
         "fullName": "Natalie Coleman"
       }
-    ]
+    ],
+    "publicationDetails": {
+      "publicationDate": "2017-12-01",
+      "bodsVersion": "0.2",
+      "publisher": {
+        "name": "XXXXXXXXX"
+      }
+    }
   },
   {
     "statementID": "487e303b-f5be-4dc2-bcae-b0803546fa29",
+    "statementDate": "2017-12-01",
     "statementType": "ownershipOrControlStatement",
     "subject": {
       "describedByEntityStatement": "3ff64336-9d26-49da-b0ce-f4685c6af139"
@@ -48,6 +65,13 @@
         },
         "startDate": "2016-07-07"
       }
-    ]
+    ],
+    "publicationDetails": {
+      "publicationDate": "2017-12-01",
+      "bodsVersion": "0.2",
+      "publisher": {
+        "name": "XXXXXXXXX"
+      }
+    }
   }
 ]

--- a/examples/workshop/modelling-bods-data/natalie-coleman-person-statement.json
+++ b/examples/workshop/modelling-bods-data/natalie-coleman-person-statement.json
@@ -5,5 +5,12 @@
     {
       "fullName": "Natalie Coleman"
     }
-  ]
+  ],
+  "publicationDetails": {
+    "publicationDate": "2017-12-01",
+    "bodsVersion": "0.2",
+    "publisher": {
+      "name": "XXXXXXXXX"
+    }
+  }
 }

--- a/examples/workshop/modelling-bods-data/ren-consulting-limited-natalie-coleman.json
+++ b/examples/workshop/modelling-bods-data/ren-consulting-limited-natalie-coleman.json
@@ -26,5 +26,12 @@
       },
       "startDate": "2016-07-07"
     }
-  ]
+  ],
+  "publicationDetails": {
+    "publicationDate": "2017-12-01",
+    "bodsVersion": "0.2",
+    "publisher": {
+      "name": "XXXXXXXXX"
+    }
+  }
 }

--- a/examples/workshop/modelling-bods-data/ren-consulting-limited.json
+++ b/examples/workshop/modelling-bods-data/ren-consulting-limited.json
@@ -8,5 +8,12 @@
       "scheme": "XE-KS-SRC",
       "id": "93821344"
     }
-  ]
+  ],
+  "publicationDetails": {
+    "publicationDate": "2017-12-01",
+    "bodsVersion": "0.2",
+    "publisher": {
+      "name": "XXXXXXXXX"
+    }
+  }
 }

--- a/examples/workshop/modelling-bods-data/renco-energy-ltd-entity-statement.json
+++ b/examples/workshop/modelling-bods-data/renco-energy-ltd-entity-statement.json
@@ -8,5 +8,12 @@
       "scheme": "XE-DI-CR",
       "id": "56462342"
     }
-  ]
+  ],
+  "publicationDetails": {
+    "publicationDate": "2017-12-01",
+    "bodsVersion": "0.2",
+    "publisher": {
+      "name": "XXXXXXXXX"
+    }
+  }
 }

--- a/examples/workshop/modelling-bods-data/renco-energy-ltd-roberto-lopez.json
+++ b/examples/workshop/modelling-bods-data/renco-energy-ltd-roberto-lopez.json
@@ -24,5 +24,12 @@
   ],
   "interestedParty": {
     "describedByPersonStatement": "e5027662-b2bf-4a55-8319-1e4ff1c7e6a2"
+  },
+  "publicationDetails": {
+    "publicationDate": "2017-12-01",
+    "bodsVersion": "0.2",
+    "publisher": {
+      "name": "XXXXXXXXX"
+    }
   }
 }

--- a/examples/workshop/modelling-bods-data/renco-holding-company-limited.json
+++ b/examples/workshop/modelling-bods-data/renco-holding-company-limited.json
@@ -8,5 +8,12 @@
       "scheme": "XE-LO-COH",
       "id": "28367095"
     }
-  ]
+  ],
+  "publicationDetails": {
+    "publicationDate": "2017-12-01",
+    "bodsVersion": "0.2",
+    "publisher": {
+      "name": "XXXXXXXXX"
+    }
+  }
 }

--- a/examples/workshop/modelling-bods-data/roberto-lopez.json
+++ b/examples/workshop/modelling-bods-data/roberto-lopez.json
@@ -5,5 +5,12 @@
     {
       "fullName": "Roberto López"
     }
-  ]
+  ],
+  "publicationDetails": {
+    "publicationDate": "2017-12-01",
+    "bodsVersion": "0.2",
+    "publisher": {
+      "name": "XXXXXXXXX"
+    }
+  }
 }

--- a/schema/components.json
+++ b/schema/components.json
@@ -519,7 +519,7 @@
         },
         "license": {
           "title": "License URL",
-          "description": "A link to licensing information for this statement.",
+          "description": "A link to the license that applies to this statement. The canonical URI of the license SHOULD be used. Publishers are encouraged to use a Public Domain Dedication or [Open Definition Conformant](http://opendefinition.org/licenses/) license.",
           "type": "string",
           "format": "uri" 
         },
@@ -538,7 +538,7 @@
     "Publisher": {
       "type": "object",
       "title": "Publisher",
-      "description": "An individual, organisation or other responsible agent making, or supporting, a given statement or annotation.",
+      "description": "Details of the organisation or individual publishing a statement.",
       "properties": {
         "name": {
           "title": "Name",

--- a/schema/components.json
+++ b/schema/components.json
@@ -552,7 +552,7 @@
           "format": "uri"
         }
       },
-      "anyof": [
+      "anyOf": [
         {
           "required": [
             "name"

--- a/schema/components.json
+++ b/schema/components.json
@@ -499,6 +499,71 @@
           "$ref": "components.json#/definitions/Source"
         }
       }
+    },
+    "PublicationDetails": {
+      "title": "Publication Details",
+      "description": "Information concerning the publication of this statement.",
+      "type": "object",
+      "properties": {
+        "publicationDate": {
+          "title": "Publication date",
+          "description": "The date on which this statement was published.",
+          "type": "string",
+          "format": "date"
+        },
+        "bodsVersion": {
+          "title": "BODS version",
+          "description": "The version of the Beneficial Ownership Data Standard to which this statement conforms, expressed as major.minor. For example: 0.2 or 1.0.",
+          "type": "string",
+          "pattern": "^(\\d+\\.)(\\d+)$"
+        },
+        "license": {
+          "title": "License URL",
+          "description": "A link to licensing information for this statement.",
+          "type": "string",
+          "format": "uri" 
+        },
+        "publisher": {
+          "title": "Publisher",
+          "description": "The publisher of this statement. In cases of self-declaration of beneficial ownership, the publisher SHOULD also be listed as an Agent under `Source.assertedBy` ",
+          "$ref": "components.json#/definitions/Publisher"
+        }
+      },
+      "required": [
+        "publicationDate",
+        "bodsVersion",
+        "publisher"
+      ]
+    },
+    "Publisher": {
+      "type": "object",
+      "title": "Publisher",
+      "description": "An individual, organisation or other responsible agent making, or supporting, a given statement or annotation.",
+      "properties": {
+        "name": {
+          "title": "Name",
+          "description": "The name of the publisher",
+          "type": "string"
+        },
+        "url": {
+          "title": "URL",
+          "description": "The URL of the parent dataset or of the publisher's website homepage",
+          "type": "string",
+          "format": "uri"
+        }
+      },
+      "oneOf": [
+        {
+          "required": [
+            "name"
+          ]
+        },
+        {
+          "required": [
+            "url"
+          ]
+        }      
+       ]
     }
   }
 }

--- a/schema/components.json
+++ b/schema/components.json
@@ -525,7 +525,7 @@
         },
         "publisher": {
           "title": "Publisher",
-          "description": "The publisher of this statement. In cases of self-declaration of beneficial ownership, the publisher SHOULD also be listed as an Agent under `Source.assertedBy` ",
+          "description": "Details of the organisation or individual publishing this statement.",
           "$ref": "components.json#/definitions/Publisher"
         }
       },

--- a/schema/components.json
+++ b/schema/components.json
@@ -552,7 +552,7 @@
           "format": "uri"
         }
       },
-      "oneOf": [
+      "anyof": [
         {
           "required": [
             "name"

--- a/schema/entity-statement.json
+++ b/schema/entity-statement.json
@@ -110,6 +110,12 @@
       "$ref": "components.json#/definitions/ReplacesStatements",
       "propertyOrder": 100
     },
+    "publicationDetails": {
+      "title": "Publication details",
+      "description": "Information concerning the original publication of this statement.",
+      "$ref": "components.json#/definitions/PublicationDetails",
+      "propertyOrder":85
+    },
     "source": {
       "title": "Source",
       "description": "The source of information about this entity, or of information that supports an anonymous or unknown entity statement.",
@@ -129,6 +135,7 @@
   "required": [
     "statementID",
     "statementType",
-    "entityType"
+    "entityType",
+    "publicationDetails"
   ]
 }

--- a/schema/ownership-or-control-statement.json
+++ b/schema/ownership-or-control-statement.json
@@ -46,6 +46,11 @@
         "$ref": "components.json#/definitions/Interest"
       }
     },
+    "publicationDetails": {
+      "title": "Publication details",
+      "description": "Information concerning the original publication of this statement.",
+      "$ref": "components.json#/definitions/PublicationDetails"
+    },
     "source": {
       "title": "Source",
       "description": "The source of the information that links the entity and the interested party, or that supports a null statement.",
@@ -67,7 +72,8 @@
     "statementID",
     "statementType",
     "subject",
-    "interestedParty"
+    "interestedParty",
+    "publicationDetails"
   ],
   "definitions": {
     "InterestedParty": {

--- a/schema/person-statement.json
+++ b/schema/person-statement.json
@@ -128,6 +128,12 @@
       },
       "propertyOrder": 80
     },
+    "publicationDetails": {
+      "title": "Publication details",
+      "description": "Information concerning the original publication of this statement.",
+      "$ref": "components.json#/definitions/PublicationDetails",
+      "propertyOrder":85
+    },
     "source": {
       "title": "Source",
       "description": "The source of information about this person, or of information that supports an unknown or anonymous person statement.",
@@ -149,7 +155,8 @@
   },
   "required": [
     "statementID",
-    "statementType"
+    "statementType",
+    "publicationDetails"
   ],
   "dependencies": {
     "missingPersonReason": [

--- a/tests/data/bods-package/fails-secondary-validation/bods-package-incorrect-ordering.json
+++ b/tests/data/bods-package/fails-secondary-validation/bods-package-incorrect-ordering.json
@@ -11,7 +11,14 @@
         "scheme":"GB-COH",
         "id":"07444723"
       }
-    ]
+    ],
+    "publicationDetails": {
+      "publicationDate": "2018-03-30",
+      "bodsVersion": "0.2",
+      "publisher": {
+        "name": "CHRINON LTD"
+      }
+    }
   },
   {
     "statementID":"fbfd0547-d0c6-4a00-b559-5c5e91c34f5c",
@@ -32,7 +39,14 @@
           "exact":100
         }
       }
-    ]
+    ],
+    "publicationDetails": {
+      "publicationDate": "2018-03-30",
+      "bodsVersion": "0.2",
+      "publisher": {
+        "name": "CHRINON LTD"
+      }
+    }
   },
     {
     "statementID":"019a93f1-e470-42e9-957b-03559861b2e2",
@@ -64,6 +78,13 @@
         "country":"GB",
         "postCode":"N3 1LF"
       }
-    ]
+    ],
+    "publicationDetails": {
+      "publicationDate": "2018-03-30",
+      "bodsVersion": "0.2",
+      "publisher": {
+        "name": "CHRINON LTD"
+      }
+    }
   }
 ]

--- a/tests/data/bods-package/fails-secondary-validation/bods-package-missing-entity-statement.json
+++ b/tests/data/bods-package/fails-secondary-validation/bods-package-missing-entity-statement.json
@@ -29,7 +29,14 @@
         "country": "GB",
         "postCode": "N3 1LF"
       }
-    ]
+    ],
+    "publicationDetails": {
+      "publicationDate": "2018-03-30",
+      "bodsVersion": "0.2",
+      "publisher": {
+        "name": "CHRINON LTD"
+      }
+    }
   },
   {
     "statementID": "fbfd0547-d0c6-4a00-b559-5c5e91c34f5c",
@@ -50,6 +57,13 @@
           "exact": 100
         }
       }
-    ]
+    ],
+    "publicationDetails": {
+      "publicationDate": "2018-03-30",
+      "bodsVersion": "0.2",
+      "publisher": {
+        "name": "CHRINON LTD"
+      }
+    }
   }
 ]

--- a/tests/data/bods-package/fails-secondary-validation/bods-package-missing-interested-party-entity-statement.json
+++ b/tests/data/bods-package/fails-secondary-validation/bods-package-missing-interested-party-entity-statement.json
@@ -11,7 +11,14 @@
         "scheme": "GB-COH",
         "id": "03209885"
       }
-    ]
+    ],
+    "publicationDetails": {
+      "publicationDate": "2018-03-30",
+      "bodsVersion": "0.2",
+      "publisher": {
+        "name": "JENEX LIMITED"
+      }
+    }
   },
   {
     "statementID": "85e7cbb2-992d-4bd2-a2f7-1274b1137f6d",
@@ -32,6 +39,13 @@
           "maximum": 100
         }
       }
-    ]
+    ],
+    "publicationDetails": {
+      "publicationDate": "2018-03-30",
+      "bodsVersion": "0.2",
+      "publisher": {
+        "name": "JENEX LIMITED"
+      }
+    }
   }
 ]

--- a/tests/data/bods-package/valid/valid-bods-package-annotations.json
+++ b/tests/data/bods-package/valid/valid-bods-package-annotations.json
@@ -19,6 +19,13 @@
         "name": "DRILLGREAT LIMITED"
         }
       ]
+    },
+    "publicationDetails": {
+      "publicationDate": "2017-05-31",
+      "bodsVersion": "0.2",
+      "publisher": {
+        "name": "MONSOON HOLDINGS (NO.1) LIMITED"
+      }
     }
   },
   {
@@ -45,6 +52,13 @@
           "name": "MONSOON HOLDINGS (NO.1) LIMITED"
         }
       ]
+    },
+    "publicationDetails": {
+      "publicationDate": "2017-05-31",
+      "bodsVersion": "0.2",
+      "publisher": {
+        "name": "MONSOON HOLDINGS (NO.1) LIMITED"
+      }
     }
   },
   {
@@ -75,6 +89,13 @@
           "name": "Jack Lord"
         }
       }
-    ]
+    ],
+    "publicationDetails": {
+      "publicationDate": "2017-05-31",
+      "bodsVersion": "0.2",
+      "publisher": {
+        "name": "MONSOON HOLDINGS (NO.1) LIMITED"
+      }
+    }
   }
 ]

--- a/tests/data/bods-package/valid/valid-bods-package-entity-owning-entity.json
+++ b/tests/data/bods-package/valid/valid-bods-package-entity-owning-entity.json
@@ -11,7 +11,14 @@
         "scheme": "GB-COH",
         "id": "03209885"
       }
-    ]
+    ],
+    "publicationDetails": {
+      "publicationDate": "2018-05-31",
+      "bodsVersion": "0.2",
+      "publisher": {
+        "name": "JENEX LIMITED"
+      }
+    }
   },
   {
     "statementID": "d36e6807-020c-4fb5-a0d4-5ab9eb971514",
@@ -25,7 +32,14 @@
         "scheme": "GB-COH",
         "id": "08150312"
       }
-    ]
+    ],
+    "publicationDetails": {
+      "publicationDate": "2018-05-31",
+      "bodsVersion": "0.2",
+      "publisher": {
+        "name": "JENEX LIMITED"
+      }
+    }
   },
   {
     "statementID": "85e7cbb2-992d-4bd2-a2f7-1274b1137f6d",
@@ -46,6 +60,13 @@
           "maximum": 100
         }
       }
-    ]
+    ],
+    "publicationDetails": {
+      "publicationDate": "2018-05-31",
+      "bodsVersion": "0.2",
+      "publisher": {
+        "name": "JENEX LIMITED"
+      }
+    }
   }
 ]

--- a/tests/data/bods-package/valid/valid-bods-package-linking-annotations.json
+++ b/tests/data/bods-package/valid/valid-bods-package-linking-annotations.json
@@ -22,6 +22,13 @@
           "uri": "https://beta.companieshouse.gov.uk/company/10970413"
         }
       ]
+    },
+    "publicationDetails": {
+      "publicationDate": "2018-03-30",
+      "bodsVersion": "0.2",
+      "publisher": {
+        "name": "A. Journo"
+      }
     }
   },
   {
@@ -44,6 +51,13 @@
           "uri": "https://beta.companieshouse.gov.uk/company/10970413"
         }
       ]
+    },
+    "publicationDetails": {
+      "publicationDate": "2018-03-30",
+      "bodsVersion": "0.2",
+      "publisher": {
+        "name": "A. Journo"
+      }
     }
   },
   {
@@ -93,6 +107,13 @@
           "uri": "https://beta.companieshouse.gov.uk/company/10970413"
         }
       ]
+    },
+    "publicationDetails": {
+      "publicationDate": "2018-03-30",
+      "bodsVersion": "0.2",
+      "publisher": {
+        "name": "A. Journo"
+      }
     }
   }
 ]

--- a/tests/data/bods-package/valid/valid-bods-package.json
+++ b/tests/data/bods-package/valid/valid-bods-package.json
@@ -11,7 +11,14 @@
         "scheme": "GB-COH",
         "id": "07444723"
       }
-    ]
+    ],
+    "publicationDetails": {
+      "publicationDate": "2017-11-18",
+      "bodsVersion": "0.2",
+      "publisher": {
+        "name": "CHRINON LTD"
+      }
+    }
   },
   {
     "statementID": "019a93f1-e470-42e9-957b-03559861b2e2",
@@ -43,7 +50,14 @@
         "country": "GB",
         "postCode": "N3 1LF"
       }
-    ]
+    ],
+    "publicationDetails": {
+      "publicationDate": "2017-11-18",
+      "bodsVersion": "0.2",
+      "publisher": {
+        "name": "CHRINON LTD"
+      }
+    }
   },
   {
     "statementID": "fbfd0547-d0c6-4a00-b559-5c5e91c34f5c",
@@ -64,6 +78,13 @@
           "exact": 100
         }
       }
-    ]
+    ],
+    "publicationDetails": {
+      "publicationDate": "2017-11-18",
+      "bodsVersion": "0.2",
+      "publisher": {
+        "name": "CHRINON LTD"
+      }
+    }
   }
 ]

--- a/tests/data/entity-statement/invalid/entity-statement-extra-field.json
+++ b/tests/data/entity-statement/invalid/entity-statement-extra-field.json
@@ -14,5 +14,12 @@
   "incorporatedInJurisdiction": {
     "code": "GB"
   },
+  "publicationDetails": {
+    "publicationDate": "2017-11-18",
+    "bodsVersion": "0.2",
+    "publisher": {
+      "name": "CHRINON LTD"
+    }
+  },
   "extra_field": "included"
 }

--- a/tests/data/entity-statement/invalid/entity-statement-invalid-date-in-source.json
+++ b/tests/data/entity-statement/invalid/entity-statement-invalid-date-in-source.json
@@ -24,5 +24,12 @@
       }
     ],
     "retrievedAt": "2018-11-14"
+  },
+  "publicationDetails": {
+    "publicationDate": "2018-12-24",
+    "bodsVersion": "0.2",
+    "publisher": {
+      "name": "A. Researcher"
+    }
   }
 }

--- a/tests/data/entity-statement/invalid/entity-statement-loose-validation-without-required-fields.json
+++ b/tests/data/entity-statement/invalid/entity-statement-loose-validation-without-required-fields.json
@@ -12,5 +12,12 @@
       "id":"00335",
       "register":"Jebel Ali Free Zone"
     }
-  ]
+  ],
+  "publicationDetails": {
+      "publicationDate": "2017-01-01",
+      "bodsVersion": "0.2",
+      "publisher": {
+        "name": "Ibrakom Fzco"
+      }
+  }
 }

--- a/tests/data/entity-statement/invalid/entity-statement-no-entity-type.json
+++ b/tests/data/entity-statement/invalid/entity-statement-no-entity-type.json
@@ -10,5 +10,12 @@
       "scheme": "GB-COH",
       "id": "07444723"
     }
-  ]
+  ],
+  "publicationDetails": {
+    "publicationDate": "2017-11-18",
+    "bodsVersion": "0.2",
+    "publisher": {
+      "name": "CHRINON LTD"
+    }
+  }
 }

--- a/tests/data/entity-statement/invalid/entity-statement-no-publication-details.json
+++ b/tests/data/entity-statement/invalid/entity-statement-no-publication-details.json
@@ -1,0 +1,24 @@
+{
+  "statementID": "1dc0e987-5c57-4a1c-b3ad-61353b66a9b7",
+  "statementType": "entityStatement",
+  "statementDate": "2017-11-18",
+  "entityType": "registeredEntity",
+  "name": "CHRINON LTD",
+  "foundingDate": "2010-11-18",
+  "identifiers": [
+    {
+      "scheme": "GB-COH",
+      "id": "07444723"
+    }
+  ],
+  "incorporatedInJurisdiction": {
+    "code": "GB"
+  },
+  "publicationDetailsTypo": {
+    "publicationDate": "2017-11-18",
+    "bodsVersion": "0.2",
+    "publisher": {
+      "name": "CHRINON LTD"
+    }
+  }
+}

--- a/tests/data/entity-statement/invalid/entity-statement-with-invalid-statement-id-no-entity-type.json
+++ b/tests/data/entity-statement/invalid/entity-statement-with-invalid-statement-id-no-entity-type.json
@@ -9,5 +9,12 @@
       "scheme": "GB-COH",
       "id": "07444723"
     }
-  ]
+  ],
+  "publicationDetails": {
+    "publicationDate": "2017-11-18",
+    "bodsVersion": "0.2",
+    "publisher": {
+      "name": "CHRINON LTD"
+    }
+  }
 }

--- a/tests/data/entity-statement/invalid/entity-statement-with-invalid-statement-id.json
+++ b/tests/data/entity-statement/invalid/entity-statement-with-invalid-statement-id.json
@@ -10,5 +10,12 @@
       "scheme": "GB-COH",
       "id": "07444723"
     }
-  ]
+  ],
+  "publicationDetails": {
+    "publicationDate": "2017-11-18",
+    "bodsVersion": "0.2",
+    "publisher": {
+      "name": "CHRINON LTD"
+    }
+  }
 }

--- a/tests/data/entity-statement/valid/valid-entity-statement-loose-validation.json
+++ b/tests/data/entity-statement/valid/valid-entity-statement-loose-validation.json
@@ -12,5 +12,12 @@
         "id":"00335",
         "schemeName":"Jebel Ali Free Zone"
       }
-    ]
+    ],
+    "publicationDetails": {
+        "publicationDate": "2016-07-01",
+        "bodsVersion": "0.2",
+        "publisher": {
+            "name": "Ibrakom Fzco"
+        }
+    }
   }

--- a/tests/data/entity-statement/valid/valid-entity-statement-transliteration-annotations.json
+++ b/tests/data/entity-statement/valid/valid-entity-statement-transliteration-annotations.json
@@ -32,5 +32,12 @@
     "type": ["officialRegister", "thirdParty"],
     "description": "Open Ownership Register, using data from the Ukraine United State Register and OpenCorporates",
     "url": "https://register.openownership.org/entities/5a7b038b9dfc3fae18417a58?transliterated=true"
+  },
+  "publicationDetails": {
+    "publicationDate": "2018-10-02",
+    "bodsVersion": "0.2",
+    "publisher": {
+      "name": "МІНІСТЕРСТВО ЮСТИЦІЇ УКРАЇНИ"
+    }
   }
 }

--- a/tests/data/entity-statement/valid/valid-entity-statement-with-source.json
+++ b/tests/data/entity-statement/valid/valid-entity-statement-with-source.json
@@ -24,5 +24,12 @@
       }
     ],
     "retrievedAt": "2018-11-14T17:23:43.977Z"
+  },
+  "publicationDetails": {
+    "publicationDate": "2019-01-05",
+    "bodsVersion": "0.2",
+    "publisher": {
+      "url": "http://example.com/"
+    }
   }
 }

--- a/tests/data/entity-statement/valid/valid-entity-statement.json
+++ b/tests/data/entity-statement/valid/valid-entity-statement.json
@@ -13,5 +13,12 @@
   ],
   "incorporatedInJurisdiction": {
     "code": "GB"
+  },
+  "publicationDetails": {
+    "publicationDate": "2017-11-18",
+    "bodsVersion": "0.2",
+    "publisher": {
+      "name": "CHRINON LTD"
+    }
   }
 }

--- a/tests/data/ownership-or-control-statement/invalid/ownership-or-control-statement-no-publication-details.json
+++ b/tests/data/ownership-or-control-statement/invalid/ownership-or-control-statement-no-publication-details.json
@@ -1,0 +1,28 @@
+{
+  "statementID": "fbfd0547-d0c6-4a00-b559-5c5e91c34f5c",
+  "statementType": "ownershipOrControlStatement",
+  "statementDate": "2017-11-18",
+  "subject": {
+    "describedByEntityStatement": "1dc0e987-5c57-4a1c-b3ad-61353b66a9b7"
+  },
+  "interestedParty": {
+    "describedByPersonStatement": "019a93f1-e470-42e9-957b-03559861b2e2"
+  },
+  "interests": [
+    {
+      "type": "shareholding",
+      "interestLevel": "direct",
+      "startDate": "2016-04-06",
+      "share": {
+        "exact": 100
+      }
+    }
+  ],
+  "publicationDetailsTypo": {
+    "publicationDate": "2017-11-18",
+    "bodsVersion": "0.2",
+    "publisher": {
+      "name": "CHRINON LTD"
+    }
+  }
+}

--- a/tests/data/ownership-or-control-statement/invalid/ownership-or-control-statement-no-statement-type.json
+++ b/tests/data/ownership-or-control-statement/invalid/ownership-or-control-statement-no-statement-type.json
@@ -16,5 +16,12 @@
         "exact": 100
       }
     }
-  ]
+  ],
+  "publicationDetails": {
+    "publicationDate": "2017-11-18",
+    "bodsVersion": "0.2",
+    "publisher": {
+      "name": "CHRINON LTD"
+    }
+  }
 }

--- a/tests/data/ownership-or-control-statement/invalid/ownership-or-control-statement-with-invalid-statement-id.json
+++ b/tests/data/ownership-or-control-statement/invalid/ownership-or-control-statement-with-invalid-statement-id.json
@@ -17,5 +17,12 @@
         "exact": 100
       }
     }
-  ]
+  ],
+  "publicationDetails": {
+    "publicationDate": "2017-11-18",
+    "bodsVersion": "0.2",
+    "publisher": {
+      "name": "CHRINON LTD"
+    }
+  }
 }

--- a/tests/data/ownership-or-control-statement/valid/ownership-or-control-statement-annotations.json
+++ b/tests/data/ownership-or-control-statement/valid/ownership-or-control-statement-annotations.json
@@ -21,6 +21,12 @@
       "statementPointerTarget": "/incorporatedIn/jurisdiction",
       "motivation" : "transformation"
     }
-
-  ]
+  ],
+  "publicationDetails": {
+    "publicationDate": "2017-11-18",
+    "bodsVersion": "0.2",
+    "publisher": {
+      "name": "MONSOON HOLDINGS (NO.1) LIMITE"
+    }
+  }
 }

--- a/tests/data/ownership-or-control-statement/valid/valid-ownership-or-control-statement.json
+++ b/tests/data/ownership-or-control-statement/valid/valid-ownership-or-control-statement.json
@@ -17,5 +17,12 @@
         "exact": 100
       }
     }
-  ]
+  ],
+  "publicationDetails": {
+    "publicationDate": "2017-11-18",
+    "bodsVersion": "0.2",
+    "publisher": {
+      "name": "CHRINON LTD"
+    }
+  }
 }

--- a/tests/data/person-statement/invalid/person-statement-no-bods-version.json
+++ b/tests/data/person-statement/invalid/person-statement-no-bods-version.json
@@ -1,0 +1,39 @@
+{
+  "statementID": "019a93f1-e470-42e9-957b-03559861b2e2",
+  "statementType": "personStatement",
+  "statementDate": "2017-11-18",
+  "personType": "knownPerson",
+  "nationalities": [
+    {
+      "code": "GB"
+    }
+  ],
+  "names": [
+    {
+      "type": "individual",
+      "fullName": "Christopher Taggart",
+      "givenName": "Christopher",
+      "familyName": "Taggart"
+    },
+    {
+      "type": "aka",
+      "fullName": "Chris Taggart"
+    }
+  ],
+  "birthDate": "1964-04",
+  "addresses": [
+    {
+      "type": "service",
+      "address": "Aston House, Cornwall Avenue, London",
+      "country": "GB",
+      "postCode": "N3 1LF"
+    }
+  ],
+  "publicationDetails": {
+    "publicationDate": "2017-11-18",
+    "bodsVersionTypo": "0.2",
+    "publisher": {
+      "name": "CHRINON LTD"
+    }
+  }
+}

--- a/tests/data/person-statement/invalid/person-statement-no-publication-date.json
+++ b/tests/data/person-statement/invalid/person-statement-no-publication-date.json
@@ -1,0 +1,39 @@
+{
+  "statementID": "019a93f1-e470-42e9-957b-03559861b2e2",
+  "statementType": "personStatement",
+  "statementDate": "2017-11-18",
+  "personType": "knownPerson",
+  "nationalities": [
+    {
+      "code": "GB"
+    }
+  ],
+  "names": [
+    {
+      "type": "individual",
+      "fullName": "Christopher Taggart",
+      "givenName": "Christopher",
+      "familyName": "Taggart"
+    },
+    {
+      "type": "aka",
+      "fullName": "Chris Taggart"
+    }
+  ],
+  "birthDate": "1964-04",
+  "addresses": [
+    {
+      "type": "service",
+      "address": "Aston House, Cornwall Avenue, London",
+      "country": "GB",
+      "postCode": "N3 1LF"
+    }
+  ],
+  "publicationDetails": {
+    "publicationDateTypo": "2017-11-18",
+    "bodsVersion": "0.2",
+    "publisher": {
+      "name": "CHRINON LTD"
+    }
+  }
+}

--- a/tests/data/person-statement/invalid/person-statement-no-publication-details.json
+++ b/tests/data/person-statement/invalid/person-statement-no-publication-details.json
@@ -1,0 +1,39 @@
+{
+  "statementID": "019a93f1-e470-42e9-957b-03559861b2e2",
+  "statementType": "personStatement",
+  "statementDate": "2017-11-18",
+  "personType": "knownPerson",
+  "nationalities": [
+    {
+      "code": "GB"
+    }
+  ],
+  "names": [
+    {
+      "type": "individual",
+      "fullName": "Christopher Taggart",
+      "givenName": "Christopher",
+      "familyName": "Taggart"
+    },
+    {
+      "type": "aka",
+      "fullName": "Chris Taggart"
+    }
+  ],
+  "birthDate": "1964-04",
+  "addresses": [
+    {
+      "type": "service",
+      "address": "Aston House, Cornwall Avenue, London",
+      "country": "GB",
+      "postCode": "N3 1LF"
+    }
+  ],
+  "publicationDetailsTypo": {
+    "publicationDate": "2017-11-18",
+    "bodsVersion": "0.2",
+    "publisher": {
+      "nameTypo": "CHRINON LTD"
+    }
+  }
+}

--- a/tests/data/person-statement/invalid/person-statement-no-publisher-sub-prop.json
+++ b/tests/data/person-statement/invalid/person-statement-no-publisher-sub-prop.json
@@ -1,0 +1,39 @@
+{
+  "statementID": "019a93f1-e470-42e9-957b-03559861b2e2",
+  "statementType": "personStatement",
+  "statementDate": "2017-11-18",
+  "personType": "knownPerson",
+  "nationalities": [
+    {
+      "code": "GB"
+    }
+  ],
+  "names": [
+    {
+      "type": "individual",
+      "fullName": "Christopher Taggart",
+      "givenName": "Christopher",
+      "familyName": "Taggart"
+    },
+    {
+      "type": "aka",
+      "fullName": "Chris Taggart"
+    }
+  ],
+  "birthDate": "1964-04",
+  "addresses": [
+    {
+      "type": "service",
+      "address": "Aston House, Cornwall Avenue, London",
+      "country": "GB",
+      "postCode": "N3 1LF"
+    }
+  ],
+  "publicationDetails": {
+    "publicationDate": "2017-11-18",
+    "bodsVersion": "0.2",
+    "publisher": {
+      "nameTypo": "CHRINON LTD"
+    }
+  }
+}

--- a/tests/data/person-statement/invalid/person-statement-no-publisher.json
+++ b/tests/data/person-statement/invalid/person-statement-no-publisher.json
@@ -1,0 +1,39 @@
+{
+  "statementID": "019a93f1-e470-42e9-957b-03559861b2e2",
+  "statementType": "personStatement",
+  "statementDate": "2017-11-18",
+  "personType": "knownPerson",
+  "nationalities": [
+    {
+      "code": "GB"
+    }
+  ],
+  "names": [
+    {
+      "type": "individual",
+      "fullName": "Christopher Taggart",
+      "givenName": "Christopher",
+      "familyName": "Taggart"
+    },
+    {
+      "type": "aka",
+      "fullName": "Chris Taggart"
+    }
+  ],
+  "birthDate": "1964-04",
+  "addresses": [
+    {
+      "type": "service",
+      "address": "Aston House, Cornwall Avenue, London",
+      "country": "GB",
+      "postCode": "N3 1LF"
+    }
+  ],
+  "publicationDetails": {
+    "publicationDate": "2017-11-18",
+    "bodsVersion": "0.2",
+    "publisherTypo": {
+      "name": "CHRINON LTD"
+    }
+  }
+}

--- a/tests/data/person-statement/invalid/person-statement-with-bad-bods-version.json
+++ b/tests/data/person-statement/invalid/person-statement-with-bad-bods-version.json
@@ -1,0 +1,39 @@
+{
+  "statementID": "019a93f1-e470-42e9-957b-03559861b2e2",
+  "statementType": "personStatement",
+  "statementDate": "2017-11-18",
+  "personType": "knownPerson",
+  "nationalities": [
+    {
+      "code": "GB"
+    }
+  ],
+  "names": [
+    {
+      "type": "individual",
+      "fullName": "Christopher Taggart",
+      "givenName": "Christopher",
+      "familyName": "Taggart"
+    },
+    {
+      "type": "aka",
+      "fullName": "Chris Taggart"
+    }
+  ],
+  "birthDate": "1964-04",
+  "addresses": [
+    {
+      "type": "service",
+      "address": "Aston House, Cornwall Avenue, London",
+      "country": "GB",
+      "postCode": "N3 1LF"
+    }
+  ],
+  "publicationDetails": {
+    "publicationDate": "2017-11-18",
+    "bodsVersion": "1",
+    "publisher": {
+      "name": "CHRINON LTD"
+    }
+  }
+}

--- a/tests/data/person-statement/invalid/person-statement-with-bad-date.json
+++ b/tests/data/person-statement/invalid/person-statement-with-bad-date.json
@@ -28,5 +28,12 @@
       "country": "GB",
       "postCode": "N3 1LF"
     }
-  ]
+  ],
+  "publicationDetails": {
+    "publicationDate": "2017-11-18",
+    "bodsVersion": "0.2",
+    "publisher": {
+      "name": "CHRINON LTD"
+    }
+  }
 }

--- a/tests/data/person-statement/invalid/person-statement-with-bad-licence-url.json
+++ b/tests/data/person-statement/invalid/person-statement-with-bad-licence-url.json
@@ -1,0 +1,40 @@
+{
+  "statementID": "019a93f1-e470-42e9-957b-03559861b2e2",
+  "statementType": "personStatement",
+  "statementDate": "2017-11-18",
+  "personType": "knownPerson",
+  "nationalities": [
+    {
+      "code": "GB"
+    }
+  ],
+  "names": [
+    {
+      "type": "individual",
+      "fullName": "Christopher Taggart",
+      "givenName": "Christopher",
+      "familyName": "Taggart"
+    },
+    {
+      "type": "aka",
+      "fullName": "Chris Taggart"
+    }
+  ],
+  "birthDate": "1964-04",
+  "addresses": [
+    {
+      "type": "service",
+      "address": "Aston House, Cornwall Avenue, London",
+      "country": "GB",
+      "postCode": "N3 1LF"
+    }
+  ],
+  "publicationDetails": {
+    "publicationDate": "2017-11-18",
+    "bodsVersion": "0.2",
+    "license": "exampledotcom",
+    "publisher": {
+      "name": "CHRINON LTD"
+    }
+  }
+}

--- a/tests/data/person-statement/invalid/person-statement-with-bad-publication-date.json
+++ b/tests/data/person-statement/invalid/person-statement-with-bad-publication-date.json
@@ -1,0 +1,39 @@
+{
+  "statementID": "019a93f1-e470-42e9-957b-03559861b2e2",
+  "statementType": "personStatement",
+  "statementDate": "2017-11-18",
+  "personType": "knownPerson",
+  "nationalities": [
+    {
+      "code": "GB"
+    }
+  ],
+  "names": [
+    {
+      "type": "individual",
+      "fullName": "Christopher Taggart",
+      "givenName": "Christopher",
+      "familyName": "Taggart"
+    },
+    {
+      "type": "aka",
+      "fullName": "Chris Taggart"
+    }
+  ],
+  "birthDate": "1964-04",
+  "addresses": [
+    {
+      "type": "service",
+      "address": "Aston House, Cornwall Avenue, London",
+      "country": "GB",
+      "postCode": "N3 1LF"
+    }
+  ],
+  "publicationDetails": {
+    "publicationDate": "2017/11/18",
+    "bodsVersion": "0.2",
+    "publisher": {
+      "name": "CHRINON LTD"
+    }
+  }
+}

--- a/tests/data/person-statement/invalid/person-statement-with-bad-publisher-url.json
+++ b/tests/data/person-statement/invalid/person-statement-with-bad-publisher-url.json
@@ -1,0 +1,39 @@
+{
+  "statementID": "019a93f1-e470-42e9-957b-03559861b2e2",
+  "statementType": "personStatement",
+  "statementDate": "2017-11-18",
+  "personType": "knownPerson",
+  "nationalities": [
+    {
+      "code": "GB"
+    }
+  ],
+  "names": [
+    {
+      "type": "individual",
+      "fullName": "Christopher Taggart",
+      "givenName": "Christopher",
+      "familyName": "Taggart"
+    },
+    {
+      "type": "aka",
+      "fullName": "Chris Taggart"
+    }
+  ],
+  "birthDate": "1964-04",
+  "addresses": [
+    {
+      "type": "service",
+      "address": "Aston House, Cornwall Avenue, London",
+      "country": "GB",
+      "postCode": "N3 1LF"
+    }
+  ],
+  "publicationDetails": {
+    "publicationDate": "2017-11-18",
+    "bodsVersion": "0.2",
+    "publisher": {
+      "url": "CHRINON LTD"
+    }
+  }
+}

--- a/tests/data/person-statement/invalid/person-statement-with-invalid-statement-id.json
+++ b/tests/data/person-statement/invalid/person-statement-with-invalid-statement-id.json
@@ -28,5 +28,12 @@
       "country": "GB",
       "postCode": "N3 1LF"
     }
-  ]
+  ],
+  "publicationDetails": {
+    "publicationDate": "2017-11-18",
+    "bodsVersion": "0.2",
+    "publisher": {
+      "name": "CHRINON LTD"
+    }
+  }
 }

--- a/tests/data/person-statement/valid/valid-person-statement.json
+++ b/tests/data/person-statement/valid/valid-person-statement.json
@@ -28,5 +28,12 @@
       "country": "GB",
       "postCode": "N3 1LF"
     }
-  ]
+  ],
+  "publicationDetails": {
+    "publicationDate": "2017-11-18",
+    "bodsVersion": "0.2",
+    "publisher": {
+      "name": "CHRINON LTD"
+    }
+  }
 }

--- a/tests/test_data.py
+++ b/tests/test_data.py
@@ -66,9 +66,20 @@ def test_valid_package_json(json_path):
     ('data/entity-statement/invalid/entity-statement-with-invalid-statement-id-no-entity-type.json', ValidationError),
     ('data/entity-statement/invalid/entity-statement-extra-field.json', ValidationError),
     ('data/entity-statement/invalid/entity-statement-invalid-date-in-source.json', ValidationError),
+    ('data/entity-statement/invalid/entity-statement-no-publication-details.json', ValidationError),
     ('data/person-statement/invalid/person-statement-with-invalid-statement-id.json', ValidationError),
     ('data/person-statement/invalid/person-statement-with-bad-date.json', ValidationError),
+    ('data/person-statement/invalid/person-statement-no-publication-details.json', ValidationError),
+    ('data/person-statement/invalid/person-statement-no-bods-version.json', ValidationError),
+    ('data/person-statement/invalid/person-statement-no-publication-date.json', ValidationError),
+    ('data/person-statement/invalid/person-statement-no-publisher-sub-prop.json', ValidationError),
+    ('data/person-statement/invalid/person-statement-no-publisher.json', ValidationError),
+    ('data/person-statement/invalid/person-statement-with-bad-bods-version.json', ValidationError),
+    ('data/person-statement/invalid/person-statement-with-bad-licence-url.json', ValidationError),
+    ('data/person-statement/invalid/person-statement-with-bad-publication-date.json', ValidationError),
+    ('data/person-statement/invalid/person-statement-with-bad-publisher-url.json', ValidationError),
     ('data/ownership-or-control-statement/invalid/ownership-or-control-statement-with-invalid-statement-id.json', ValidationError),
+    ('data/ownership-or-control-statement/invalid/ownership-or-control-statement-no-publication-details.json', ValidationError),
     ('data/ownership-or-control-statement/invalid/ownership-or-control-statement-no-statement-type.json', MissingStatementTypeError),
 ])
 def test_invalid_statement_json(json_path, error):
@@ -131,11 +142,44 @@ def test_invalid_package_json(json_path, json_paths, error):
         "'too-short-so-fail' is too short",
         "'entityType' is a required property",
     }),
+    ('data/entity-statement/invalid/entity-statement-no-publication-details.json', {
+        "'publicationDetails' is a required property"
+    }),
+    ('data/ownership-or-control-statement/invalid/ownership-or-control-statement-no-publication-details.json', {
+        "'publicationDetails' is a required property"
+    }),
+    ('data/person-statement/invalid/person-statement-no-publication-details.json', {
+        "'publicationDetails' is a required property"
+    }),
     ('data/person-statement/invalid/person-statement-with-invalid-statement-id.json', {
         "'too-short-so-fail' is too short"
     }),
     ('data/person-statement/invalid/person-statement-with-bad-date.json', {
         "'Tuesday' is not a 'date'",
+    }),
+    ('data/person-statement/invalid/person-statement-no-bods-version.json', {
+        "'bodsVersion' is a required property",
+    }),
+    ('data/person-statement/invalid/person-statement-no-publication-date.json', {
+        "'publicationDate' is a required property",
+    }),
+    ('data/person-statement/invalid/person-statement-no-publisher-sub-prop.json', {
+        "OrderedDict([('nameTypo', 'CHRINON LTD')]) is not valid under any of the given schemas",
+    }),
+    ('data/person-statement/invalid/person-statement-no-publisher.json', {
+        "'publisher' is a required property",
+    }),
+    ('data/person-statement/invalid/person-statement-with-bad-bods-version.json', {
+        "'1' does not match '^(\\\\d+\\\\.)(\\\\d+)$'",
+    }),
+    ('data/person-statement/invalid/person-statement-with-bad-licence-url.json', {
+        "'exampledotcom' is not a 'uri'",
+    }),
+    ('data/person-statement/invalid/person-statement-with-bad-publication-date.json', {
+        "'2017/11/18' is not a 'date'",
+    }),
+    ('data/person-statement/invalid/person-statement-with-bad-publisher-url.json', {
+        "'CHRINON LTD' is not a 'uri'",
     }),
     ('data/entity-statement/invalid/entity-statement-invalid-date-in-source.json', {
         "'2018-11-14' is not a 'date-time'",


### PR DESCRIPTION
Since the new publicationDetails component is required, I've added it to all the BODS json files at the top level in the 'examples' directory. 

I've added @kindly as the main reviewer, but I think we should hold off merging this into 0.2-dev until @ScatteredInk has taken a look too.