### PR TITLE
Privacy notice added to 'About' section of docs - fixes #85

### DIFF
--- a/docs/about/index.md
+++ b/docs/about/index.md
@@ -42,6 +42,7 @@ If you would like to be involved in the development and review of the Standard, 
    governance
    credits
    support
+   privacy-notice
    
 
 ```

--- a/docs/about/privacy-notice.md
+++ b/docs/about/privacy-notice.md
@@ -3,17 +3,15 @@ Privacy Notice
 
 ReadTheDocs provide the platform these docs are hosted on, for information about how they collect and process personal data, [see their Privacy Policy](https://docs.readthedocs.io/en/latest/privacy-policy.html).
 
-Open Ownership is committed to ensuring that your privacy is protected. This privacy notice sets out how we collect and process any personal data when you use this website.
+OpenOwnership is committed to ensuring that your privacy is protected. This privacy notice sets out how we collect and process any personal data when you use this website.
 
 We may change this notice from time to time by updating this page. This notice is effective from 24th May 2018.
 
-Data controller: <br/>
-<br/>
-Contact us if would like a copy of the information held on you or if you believe that any information we are holding on you is incorrect or incomplete.
+You can contact us at OpenOwnership (as the data controller) if would like a copy of the information held on you or if you believe that any information we are holding on you is incorrect or incomplete.
 
 You have the following rights concerning this data:
 
-*   Right to be informed, which is the purpose of this privacy notice
+*   Right to be informed, which is the purpose of this privacy notice.
 *   Right to Access, Rectification, Erasure, and to Restrict Processing. Note that the right to Erasure and Restrict Processing are balanced against our legitimate interests. Where relevant, you need to provide information to re-identify yourself from our pseudonymised data, see [GDPR Article 11](https://gdpr-info.eu/art-11-gdpr/)
 *   Right to object to our processing.
 
@@ -38,14 +36,14 @@ Personal data we collect:
 
 We do not use this data to personally identify individuals, but it is possible that it could be used to do so, particularly if combined with other datasets.
 
-You can opt out of this processing: If you have set your web browser to "I do not want to be tracked" (DoNotTrack is enabled) then Matomo will not track your visit.
+You can opt out of this processing: if you have set your web browser to "I do not want to be tracked" (DoNotTrack is enabled) then Matomo will not track your visit.
 
-Matomo also it’s own opt out mechanism:
+Matomo also has its own opt out mechanism:
 <!-- opt out iframe - clicking this will mean people can opt out of tracking -->
 <iframe style="border: 1; height: 150px; width: 600px;" src="https://mon.opendataservices.coop/piwik/index.php?module=CoreAdminHome&amp;action=optOut&amp;language=en"></iframe>
 
 Data processors: Open Data Services Co-operative Limited, Bytemark.
 
-The data controller (Open Ownership) is based in the USA.
+The data controller (OpenOwnership) is based in the USA.
 
 The data is kept indefinitely, in pseudonymised form.

--- a/docs/about/privacy-notice.md
+++ b/docs/about/privacy-notice.md
@@ -12,7 +12,7 @@ You can contact us at OpenOwnership (as the data controller) if would like a cop
 You have the following rights concerning this data:
 
 *   Right to be informed, which is the purpose of this privacy notice.
-*   Right to Access, Rectification, Erasure, and to Restrict Processing. Note that the right to Erasure and Restrict Processing are balanced against our legitimate interests. Where relevant, you need to provide information to re-identify yourself from our pseudonymised data, see [GDPR Article 11](https://gdpr-info.eu/art-11-gdpr/)
+*   Right to Access, Rectification, Erasure, and to Restrict Processing. Note that the right to Erasure and Restrict Processing are balanced against our legitimate interests. Where relevant, you need to provide information to re-identify yourself from our pseudonymised data, see [GDPR Article 11](https://gdpr-info.eu/art-11-gdpr/).
 *   Right to object to our processing.
 
 Our supervisory authority is the [ICO in the UK](https://ico.org.uk/). You have the right to lodge a complaint with them.


### PR DESCRIPTION
In the course of looking at the privacy notice file, I realise that there is another problem. There's some [iframe code](https://github.com/openownership/data-standard/blob/0.2-dev-privacy-85/docs/about/privacy-notice.md) - a Matomo form? - which isn't working for some reason.

When I build the docs locally, the iframe is stripped out when I view the browser's HTML (in Chromium & Firefox).

I'm adding this PR anyway since the problem may not be in the privacy-notice.md file itself. I'll ask James for a quick review and work out whether to leave the Matomo iframe out in the file.