### PR TITLE
fix a broken link

### DIFF
--- a/docs/schema/guidance/index.rst
+++ b/docs/schema/guidance/index.rst
@@ -3,7 +3,7 @@ Technical guidance
 
 .. attention:: 
     
-    This is v0.1 of the Beneficial Ownership Data Standard. It includes updates to the data model and additional codelist information. Implementers should be aware that future changes are anticipated, before a version 1.0 release. See the :any:`Changelog <changelog>` and `About <../about>`_ pages for more information.
+    This is v0.1 of the Beneficial Ownership Data Standard. It includes updates to the data model and additional codelist information. Implementers should be aware that future changes are anticipated, before a version 1.0 release. See the :any:`Changelog <changelog>` and `About <../../about>`_ pages for more information.
 
     **MUST** and **SHOULD** are used in the schema to denote required and recommended elements of the Standard, as defined in `RFC2119 <https://tools.ietf.org/html/rfc2119>`_.
 


### PR DESCRIPTION
I came across a broken link on [this page](https://standard.openownership.org/en/v0-1/schema/guidance/index.html) when browsing the site. Let's fix it.