### PR TITLE
Use flake8 and CSV tests from OCDS standard-maintenance-scripts

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -2,8 +2,13 @@ sudo: false
 language: python
 python: 
   - "3.5"
+env:
+  global:
+    # Pinned to a commit on the master branch
+    - BASEDIR="https://raw.githubusercontent.com/open-contracting/standard-maintenance-scripts/c3b4fc9499852baed9fc0160638162aa0e61381f"
 install: 
   - "pip install -r requirements_test.txt"
+  - curl -s -S --retry 3 $BASEDIR/tests/install.sh | bash -
 script:
   - "py.test"
   - "flake8 tests"

--- a/.travis.yml
+++ b/.travis.yml
@@ -10,5 +10,5 @@ install:
   - "pip install -r requirements_test.txt"
   - curl -s -S --retry 3 $BASEDIR/tests/install.sh | bash -
 script:
+  - "./open-contracting_standard-maintenance-scripts_tests_script.sh"
   - "py.test"
-  - "flake8 tests"

--- a/open-contracting_standard-maintenance-scripts_tests_script.sh
+++ b/open-contracting_standard-maintenance-scripts_tests_script.sh
@@ -1,5 +1,7 @@
 # This is https://github.com/open-contracting/standard-maintenance-scripts/blob/c3b4fc9499852baed9fc0160638162aa0e61381f/tests/script.sh
-# with some lines commented out.
+# with some bits commented out, because they fail.
+# A list of the work necessary to make all tests pass is at
+# https://github.com/openownership/data-standard/issues/171#issuecomment-523926459
 set -e
 
 # Lint Python
@@ -16,7 +18,7 @@ flake8 --max-line-length 119
 ## /tmp/bin/mdl --git-recurse --style /tmp/mdlrc.rb .
 #
 ## Validate CSV, JSON and JSON Schema
-#curl -s -S --retry 3 -o /tmp/test_csv.py $BASEDIR/tests/test_csv.py
+curl -s -S --retry 3 -o /tmp/test_csv.py $BASEDIR/tests/test_csv.py
 #curl -s -S --retry 3 -o /tmp/test_json.py $BASEDIR/tests/test_json.py
 #curl -s -S --retry 3 -o /tmp/test_readme.py $BASEDIR/tests/test_readme.py
-#py.test -rs --tb=line /tmp/test_csv.py /tmp/test_json.py /tmp/test_readme.py
+py.test -rs --tb=line /tmp/test_csv.py #/tmp/test_json.py /tmp/test_readme.py

--- a/open-contracting_standard-maintenance-scripts_tests_script.sh
+++ b/open-contracting_standard-maintenance-scripts_tests_script.sh
@@ -1,0 +1,22 @@
+# This is https://github.com/open-contracting/standard-maintenance-scripts/blob/c3b4fc9499852baed9fc0160638162aa0e61381f/tests/script.sh
+# with some lines commented out.
+set -e
+
+# Lint Python
+flake8 --max-line-length 119
+## Repositories using tox run isort independently.
+#if ! [ -x "$(command -v tox)" ]; then
+#  isort --check-only --ignore-whitespace --line-width 119
+#fi
+#
+## Lint Markdown
+## See https://github.com/open-contracting/standard-maintenance-scripts/issues/26
+## See https://ocds-standard-development-handbook.readthedocs.io/en/latest/coding/
+## curl -s -S -o /tmp/mdlrc.rb $BASEDIR/fixtures/mdlrc.rb
+## /tmp/bin/mdl --git-recurse --style /tmp/mdlrc.rb .
+#
+## Validate CSV, JSON and JSON Schema
+#curl -s -S --retry 3 -o /tmp/test_csv.py $BASEDIR/tests/test_csv.py
+#curl -s -S --retry 3 -o /tmp/test_json.py $BASEDIR/tests/test_json.py
+#curl -s -S --retry 3 -o /tmp/test_readme.py $BASEDIR/tests/test_readme.py
+#py.test -rs --tb=line /tmp/test_csv.py /tmp/test_json.py /tmp/test_readme.py

--- a/schema/codelists/addressType.csv
+++ b/schema/codelists/addressType.csv
@@ -4,4 +4,4 @@ residence,Residential address,An address where someone lives. This must only be 
 registered,Registered address,An official address for delivering statutory mail and legal notices which must be provided to company registers. This must only be used to describe entities.,
 service,Service address,An address which can be used as an alternative to a residential address for the purpose of receiving post. This must only be used for natural persons.,
 alternative,Alternative address,An address provided in addition to the primary address for this entity or person that is neither a service nor a registered address.,
-business, Business address,A place where the entity conducts its business.,
+business,Business address,A place where the entity conducts its business.,

--- a/schema/codelists/addressType.csv
+++ b/schema/codelists/addressType.csv
@@ -1,7 +1,7 @@
 code,title,description,technical note
-placeOfBirth,Place of birth,The place where a person was born. This must only be used to describe natural persons. Only a town and country are required.
-residence,Residential address,An address where someone lives. This must only be used for natural persons.
-registered,Registered address,An official address for delivering statutory mail and legal notices which must be provided to company registers. This must only be used to describe entities.
-service,Service address,An address which can be used as an alternative to a residential address for the purpose of receiving post. This must only be used for natural persons.
-alternative,Alternative address,An address provided in addition to the primary address for this entity or person that is neither a service nor a registered address.
-business, Business address,A place where the entity conducts its business.
+placeOfBirth,Place of birth,The place where a person was born. This must only be used to describe natural persons. Only a town and country are required.,
+residence,Residential address,An address where someone lives. This must only be used for natural persons.,
+registered,Registered address,An official address for delivering statutory mail and legal notices which must be provided to company registers. This must only be used to describe entities.,
+service,Service address,An address which can be used as an alternative to a residential address for the purpose of receiving post. This must only be used for natural persons.,
+alternative,Alternative address,An address provided in addition to the primary address for this entity or person that is neither a service nor a registered address.,
+business, Business address,A place where the entity conducts its business.,

--- a/schema/codelists/annotationMotivation.csv
+++ b/schema/codelists/annotationMotivation.csv
@@ -1,6 +1,6 @@
 code,title,description,technical note
-commenting,Commenting,"The description field provides contextual comments for a field, object or statement."
-correcting,Correcting,"The value of this field, object or statement has been corrected, using the method in the description field and/or from the original value given in the description field."
-identifying,Identifying,"The value of this field, object or statement has been augmented or processed for the purpose of identifying natural persons or legal entities, using the method in the description field."
-linking,Linking,"The description explains how linked material relates to the field, object or statement. A URL to linked material MUST be provided in the `url` field."
-transformation,Transformation,"The values of this field, object or statement have been changed from their original form using the method in the description field. The transformed representation may be provided in the transformedContent field."
+commenting,Commenting,"The description field provides contextual comments for a field, object or statement.",
+correcting,Correcting,"The value of this field, object or statement has been corrected, using the method in the description field and/or from the original value given in the description field.",
+identifying,Identifying,"The value of this field, object or statement has been augmented or processed for the purpose of identifying natural persons or legal entities, using the method in the description field.",
+linking,Linking,"The description explains how linked material relates to the field, object or statement. A URL to linked material MUST be provided in the `url` field.",
+transformation,Transformation,"The values of this field, object or statement have been changed from their original form using the method in the description field. The transformed representation may be provided in the transformedContent field.",

--- a/schema/codelists/entityType.csv
+++ b/schema/codelists/entityType.csv
@@ -1,6 +1,6 @@
 code,title,description,technical note
-registeredEntity,Registered Entity,"Any legal entity created through an act of official registration. In most cases, registered entities will have an official issued identifier."
-legalEntity,Legal entity,"A body with distinct legal personality, such as a government department or international institution, but which is not otherwise uniquely identified in some official register."
-arrangement,Arrangement,"An artificial entity, created by agreements, contracts or other processes."
-anonymousEntity,Anonymous entity,"An entity that has been identified, but for which no identifying information is being published."
-unknownEntity,Unknown entity,"An entity that has not been identified."
+registeredEntity,Registered Entity,"Any legal entity created through an act of official registration. In most cases, registered entities will have an official issued identifier.",
+legalEntity,Legal entity,"A body with distinct legal personality, such as a government department or international institution, but which is not otherwise uniquely identified in some official register.",
+arrangement,Arrangement,"An artificial entity, created by agreements, contracts or other processes.",
+anonymousEntity,Anonymous entity,"An entity that has been identified, but for which no identifying information is being published.",
+unknownEntity,Unknown entity,An entity that has not been identified.,

--- a/schema/codelists/interestLevel.csv
+++ b/schema/codelists/interestLevel.csv
@@ -1,4 +1,4 @@
 code,title,description,technical note
-direct,Direct,"The interest is held directly."
-indirect,Indirect,"The interest is held through one or more intermediate entities (including arrangements).",
-unknown,Unknown,"The interest may be direct or indirect."
+direct,Direct,The interest is held directly.,
+indirect,Indirect,The interest is held through one or more intermediate entities (including arrangements).,
+unknown,Unknown,The interest may be direct or indirect.,

--- a/schema/codelists/interestType.csv
+++ b/schema/codelists/interestType.csv
@@ -1,15 +1,15 @@
 code,title,description,technical note
-shareholding,Shareholding,"An economic interest in an entity gained by holding shares."
-voting-rights,Voting rights,"A controlling interest in an entity gained by holding shares. Defined as the right of shareholders to vote on matters of corporate policy, including decisions on the makeup of the board of directors, issuing securities, initiating corporate actions and making substantial changes in the corporation's operations."
-appointment-of-board,Appointment of board,"A controlling interest in an entity. Defined as the absolute right to appoint members of the board of directors."
-other-influence-or-control,Other influence or control, "Any influence or control in an entity that is distinct from being a shareholder, having voting rights or having the absolute right to appoint to the board."
-senior-managing-official,Senior managing official,"A controlling interest in an entity gained by employment. Defined as the person who exercises control over the management of the entity."
-settlor-of-trust,Settlor of trust,"A controlling interest in a trust. Defined as the person who gives property into trust for the benefit of beneficiaries. In some legal systems, a settlor is also referred to as a trustor, or occasionally, a grantor or donor."
-trustee-of-trust,Trustee of a trust.,"A controlling interest in a trust. Defined as a person or firm that holds and administers property or assets for the benefit of a third party."
-protector-of-trust,Protector of a trust,"A controlling interest in a trust. Defined as a person appointed under the trust instrument to direct or restrain the trustees in relation to their administration of the trust."
-beneficiary-of-trust,Beneficiary of a trust,"An economic interest in a trust. Defined as a person or legal entity who profits from a trust's holdings or activities."
-other-influence-or-control-of-trust,Other influence or control of a trust,"Any influence or control in a trust that is distinct from being a settlor, trustee, protector or beneficiary."
-rights-to-surplus-assets-on-dissolution,Rights to surplus assets on dissolution,"The right to a share in the amount of an asset or resource that exceeds the portion that is utilized upon the winding up of an entity."
-rights-to-profit-or-income,Rights to receive profits or income,"An economic interest in an entity. Defined as beneficial ownership rights beyond those otherwise implied by ownership structures that are granted by contract."
-rights-granted-by-contract,Rights granted by contract,"An interest that is granted by contract."
-conditional-rights-granted-by-contract,Conditional rights granted by contract, "An interest that exists only if some contractual condition is met."
+shareholding,Shareholding,An economic interest in an entity gained by holding shares.,
+voting-rights,Voting rights,"A controlling interest in an entity gained by holding shares. Defined as the right of shareholders to vote on matters of corporate policy, including decisions on the makeup of the board of directors, issuing securities, initiating corporate actions and making substantial changes in the corporation's operations.",
+appointment-of-board,Appointment of board,A controlling interest in an entity. Defined as the absolute right to appoint members of the board of directors.,
+other-influence-or-control,Other influence or control,"Any influence or control in an entity that is distinct from being a shareholder, having voting rights or having the absolute right to appoint to the board.",
+senior-managing-official,Senior managing official,A controlling interest in an entity gained by employment. Defined as the person who exercises control over the management of the entity.,
+settlor-of-trust,Settlor of trust,"A controlling interest in a trust. Defined as the person who gives property into trust for the benefit of beneficiaries. In some legal systems, a settlor is also referred to as a trustor, or occasionally, a grantor or donor.",
+trustee-of-trust,Trustee of a trust.,A controlling interest in a trust. Defined as a person or firm that holds and administers property or assets for the benefit of a third party.,
+protector-of-trust,Protector of a trust,A controlling interest in a trust. Defined as a person appointed under the trust instrument to direct or restrain the trustees in relation to their administration of the trust.,
+beneficiary-of-trust,Beneficiary of a trust,An economic interest in a trust. Defined as a person or legal entity who profits from a trust's holdings or activities.,
+other-influence-or-control-of-trust,Other influence or control of a trust,"Any influence or control in a trust that is distinct from being a settlor, trustee, protector or beneficiary.",
+rights-to-surplus-assets-on-dissolution,Rights to surplus assets on dissolution,The right to a share in the amount of an asset or resource that exceeds the portion that is utilized upon the winding up of an entity.,
+rights-to-profit-or-income,Rights to receive profits or income,An economic interest in an entity. Defined as beneficial ownership rights beyond those otherwise implied by ownership structures that are granted by contract.,
+rights-granted-by-contract,Rights granted by contract,An interest that is granted by contract.,
+conditional-rights-granted-by-contract,Conditional rights granted by contract,An interest that exists only if some contractual condition is met.,

--- a/schema/codelists/nameType.csv
+++ b/schema/codelists/nameType.csv
@@ -1,7 +1,7 @@
 code,title,description,technical note
-individual,Legal name,"A name that identifies the person for legal, administrative and other official purposes. A person's legal name will usually be the one that is found on official government documents."
-translation,Translation of name,"A translation of the person's individual name in a different language."
-transliteration, Transliteration of name, "A transliteration of the person's individual name in a different script.",
-former,Former name,"A name that the person has used in the past."
-alternative, Alternative name,"Another name that the person is known by. This might be an alias, a nickname or a name that the person is also known as (aka)."
-birth,Birth name, "The legal name of the person at birth."
+individual,Legal name,"A name that identifies the person for legal, administrative and other official purposes. A person's legal name will usually be the one that is found on official government documents.",
+translation,Translation of name,A translation of the person's individual name in a different language.,
+transliteration, Transliteration of name,A transliteration of the person's individual name in a different script.,
+former,Former name,A name that the person has used in the past.,
+alternative, Alternative name,"Another name that the person is known by. This might be an alias, a nickname or a name that the person is also known as (aka).",
+birth,Birth name,The legal name of the person at birth.,

--- a/schema/codelists/nameType.csv
+++ b/schema/codelists/nameType.csv
@@ -1,7 +1,7 @@
 code,title,description,technical note
 individual,Legal name,"A name that identifies the person for legal, administrative and other official purposes. A person's legal name will usually be the one that is found on official government documents.",
 translation,Translation of name,A translation of the person's individual name in a different language.,
-transliteration, Transliteration of name,A transliteration of the person's individual name in a different script.,
+transliteration,Transliteration of name,A transliteration of the person's individual name in a different script.,
 former,Former name,A name that the person has used in the past.,
-alternative, Alternative name,"Another name that the person is known by. This might be an alias, a nickname or a name that the person is also known as (aka).",
+alternative,Alternative name,"Another name that the person is known by. This might be an alias, a nickname or a name that the person is also known as (aka).",
 birth,Birth name,The legal name of the person at birth.,

--- a/schema/codelists/personType.csv
+++ b/schema/codelists/personType.csv
@@ -1,4 +1,4 @@
 code,title,description,technical note
-knownPerson,Known person,"This person has been identified, and information such as names, identifiers or biographical information may be provided about them."
-anonymousPerson,Anonymous person,"This person has been identified, but identifying information is being withheld. The reason for non disclosure should be given in the accompanying `missingInfoReason` field."
-unknownPerson,Unknown person,"The identity of this person has not been discovered or confirmed."
+knownPerson,Known person,"This person has been identified, and information such as names, identifiers or biographical information may be provided about them.",
+anonymousPerson,Anonymous person,"This person has been identified, but identifying information is being withheld. The reason for non disclosure should be given in the accompanying `missingInfoReason` field.",
+unknownPerson,Unknown person,The identity of this person has not been discovered or confirmed.,

--- a/schema/codelists/sourceType.csv
+++ b/schema/codelists/sourceType.csv
@@ -1,6 +1,6 @@
 code,title,description,technical note
-selfDeclaration,Self declaration,"The information was provided by the individual or entity referred to in this statement, or by their authorised representative."
-officialRegister,Official register,"The information was taken from an official register."
-thirdParty,Third party,"The information was provided by a third party, not directly related to the individual, entity or interests described by this statement."
-primaryResearch,Primary research,"The information was provided as a result of research into primary sources."
-verified,Verified,"The information has been verified through the process documented in the associated description."
+selfDeclaration,Self declaration,"The information was provided by the individual or entity referred to in this statement, or by their authorised representative.",
+officialRegister,Official register,The information was taken from an official register.,
+thirdParty,Third party,"The information was provided by a third party, not directly related to the individual, entity or interests described by this statement.",
+primaryResearch,Primary research,The information was provided as a result of research into primary sources.,
+verified,Verified,The information has been verified through the process documented in the associated description.,

--- a/schema/codelists/statementType.csv
+++ b/schema/codelists/statementType.csv
@@ -1,4 +1,4 @@
 code,title,description,technical note
 personStatement,Person Statement,"The statement contains information known about a natural person at a particular point in time, or from a given submission of information.",The parent object should be validated using the Person Statement schema.
 entityStatement,Entity Statement,"The statement contains information that identifies and describes an entity at a particular point in time, or from a given submission of information.",The parent object should be validated using the Entity Statement schema.
-ownershipOrControlStatement,Ownership-or-control Statement,"The statement contains details of the interests held by an interested party in an entity at a particular point in time.",The parent object should be validated using the Ownership-or-control Statement schema.
+ownershipOrControlStatement,Ownership-or-control Statement,The statement contains details of the interests held by an interested party in an entity at a particular point in time.,The parent object should be validated using the Ownership-or-control Statement schema.

--- a/schema/codelists/unspecifiedReason.csv
+++ b/schema/codelists/unspecifiedReason.csv
@@ -1,8 +1,8 @@
 code,title,description,technical note
-no-beneficial-owners,No beneficial owners,"There are no beneficial owners who need to disclose ownership according to the rules under which this statement is made."
-subject-unable-to-confirm-or-identify-beneficial-owner,Subject unable to confirm or identify beneficial owner,"The subject of this ownership or control statement has, as the disclosing party, been unwilling or unable to confirm the existence identify a beneficial owner."
-interested-party-has-not-provided-information,Interested party has not provided information,"The interested party in this ownership or control statement has not provided enough information to identify or confirm the identity of the beneficial owner."
-subject-exempt-from-disclosure,Subject exempt from disclosure,"The subject of this ownership or control statement is not required to disclose its beneficial owner. (Replaces noNotifiableOwners.)"
-interested-party-exempt-from-disclosure,Interested party exempt from disclosure,"The interested party in this ownership or control statement is exempt from having their identity disclosed."
-unknown,Unknown reason,"The reason an interested party cannot be provided is not known."
-information-unknown-to-publisher,Information unknown to the publisher of the data,"A publisher does not have access to information on this person or entity. This should not generally be used in situations where one party has the responsibility to provide such information."
+no-beneficial-owners,No beneficial owners,There are no beneficial owners who need to disclose ownership according to the rules under which this statement is made.,
+subject-unable-to-confirm-or-identify-beneficial-owner,Subject unable to confirm or identify beneficial owner,"The subject of this ownership or control statement has, as the disclosing party, been unwilling or unable to confirm the existence identify a beneficial owner.",
+interested-party-has-not-provided-information,Interested party has not provided information,The interested party in this ownership or control statement has not provided enough information to identify or confirm the identity of the beneficial owner.,
+subject-exempt-from-disclosure,Subject exempt from disclosure,The subject of this ownership or control statement is not required to disclose its beneficial owner. (Replaces noNotifiableOwners.),
+interested-party-exempt-from-disclosure,Interested party exempt from disclosure,The interested party in this ownership or control statement is exempt from having their identity disclosed.,
+unknown,Unknown reason,The reason an interested party cannot be provided is not known.,
+information-unknown-to-publisher,Information unknown to the publisher of the data,A publisher does not have access to information on this person or entity. This should not generally be used in situations where one party has the responsibility to provide such information.,


### PR DESCRIPTION
We already run flake8, but only against the test directly, so this includes some changes to `docs/conf.py` so that it passes.

This runs tests that all CSVs should pass. Tests specifically against codelists don't run, because the BODS codelists don't get detected as such.