### PR TITLE
Theme rebrand (onto v0-1)

### DIFF
--- a/docs/_assets/Diag1-simpleOwn.svg
+++ b/docs/_assets/Diag1-simpleOwn.svg
@@ -76,7 +76,7 @@
       <path
          id="path4371"
          d="M 0,0 5,-5 -12.5,0 5,5 0,0 Z"
-         style="fill:#00deb6;fill-opacity:1;fill-rule:evenodd;stroke:#00deb6;stroke-width:1pt;stroke-opacity:1"
+         style="fill:#3c31d4;fill-opacity:1;fill-rule:evenodd;stroke:#3c31d4;stroke-width:1pt;stroke-opacity:1"
          transform="matrix(-0.8,0,0,-0.8,-10,0)"
          inkscape:connector-curvature="0" />
     </marker>
@@ -91,7 +91,7 @@
       <path
          id="path4377"
          d="M 0,0 5,-5 -12.5,0 5,5 0,0 Z"
-         style="fill:#00deb6;fill-opacity:1;fill-rule:evenodd;stroke:#00deb6;stroke-width:1pt;stroke-opacity:1"
+         style="fill:#3c31d4;fill-opacity:1;fill-rule:evenodd;stroke:#3c31d4;stroke-width:1pt;stroke-opacity:1"
          transform="matrix(-0.4,0,0,-0.4,-4,0)"
          inkscape:connector-curvature="0" />
     </marker>
@@ -106,12 +106,12 @@
       <path
          id="path4374"
          d="M 0,0 5,-5 -12.5,0 5,5 0,0 Z"
-         style="fill:#00deb6;fill-opacity:1;fill-rule:evenodd;stroke:#00deb6;stroke-width:1pt;stroke-opacity:1"
+         style="fill:#3c31d4;fill-opacity:1;fill-rule:evenodd;stroke:#3c31d4;stroke-width:1pt;stroke-opacity:1"
          transform="matrix(0.4,0,0,0.4,4,0)"
          inkscape:connector-curvature="0" />
     </marker>
     <style
-       id="style5">.cls-1,.cls-10,.cls-11,.cls-7,.cls-8{fill:none;}.cls-1,.cls-11{stroke:#00deb6;}.cls-1,.cls-10,.cls-11,.cls-7{stroke-miterlimit:10;}.cls-2{fill:#00deb6;}.cls-3{font-size:16px;fill:#262737;}.cls-12,.cls-3{font-family:HKGrotesk-SemiBold, HK Grotesk;font-weight:700;}.cls-4{letter-spacing:-0.03em;}.cls-5{letter-spacing:-0.02em;}.cls-6{letter-spacing:0em;}.cls-7{stroke:#262737;}.cls-11,.cls-7{stroke-width:5px;}.cls-9{letter-spacing:-0.01em;}.cls-10{stroke:#e6e6e6;}.cls-12{font-size:12px;fill:gray;}.cls-13{letter-spacing:-0.03em;}.cls-14{letter-spacing:-0.01em;}.cls-15{letter-spacing:-0.02em;}.cls-16{letter-spacing:0em;}.cls-17{letter-spacing:0em;}.cls-18{letter-spacing:0em;}</style>
+       id="style5">.cls-1,.cls-10,.cls-11,.cls-7,.cls-8{fill:none;}.cls-1,.cls-11{stroke:#3c31d4;}.cls-1,.cls-10,.cls-11,.cls-7{stroke-miterlimit:10;}.cls-2{fill:#3c31d4;}.cls-3{font-size:16px;fill:#262737;}.cls-12,.cls-3{font-family:HKGrotesk-SemiBold, HK Grotesk;font-weight:700;}.cls-4{letter-spacing:-0.03em;}.cls-5{letter-spacing:-0.02em;}.cls-6{letter-spacing:0em;}.cls-7{stroke:#262737;}.cls-11,.cls-7{stroke-width:5px;}.cls-9{letter-spacing:-0.01em;}.cls-10{stroke:#e6e6e6;}.cls-12{font-size:12px;fill:gray;}.cls-13{letter-spacing:-0.03em;}.cls-14{letter-spacing:-0.01em;}.cls-15{letter-spacing:-0.02em;}.cls-16{letter-spacing:0em;}.cls-17{letter-spacing:0em;}.cls-18{letter-spacing:0em;}</style>
     <marker
        inkscape:stockid="Arrow1Mstart"
        orient="auto"
@@ -124,7 +124,7 @@
          inkscape:connector-curvature="0"
          id="path4374-0"
          d="M 0,0 5,-5 -12.5,0 5,5 0,0 Z"
-         style="fill:#00deb6;fill-opacity:1;fill-rule:evenodd;stroke:#00deb6;stroke-width:1pt;stroke-opacity:1"
+         style="fill:#3c31d4;fill-opacity:1;fill-rule:evenodd;stroke:#3c31d4;stroke-width:1pt;stroke-opacity:1"
          transform="matrix(0.4,0,0,0.4,4,0)" />
     </marker>
     <clipPath
@@ -179,7 +179,7 @@
          inkscape:connector-curvature="0"
          id="path4374-0-7"
          d="M 0,0 5,-5 -12.5,0 5,5 0,0 Z"
-         style="fill:#88c9d3;fill-opacity:1;fill-rule:evenodd;stroke:#88c9d3;stroke-width:1pt;stroke-opacity:1"
+         style="fill:#3c31d4;fill-opacity:1;fill-rule:evenodd;stroke:#3c31d4;stroke-width:1pt;stroke-opacity:1"
          transform="matrix(0.4,0,0,0.4,4,0)" />
     </marker>
     <marker
@@ -194,7 +194,7 @@
          inkscape:connector-curvature="0"
          id="path4374-0-7-0"
          d="M 0,0 5,-5 -12.5,0 5,5 0,0 Z"
-         style="fill:#88c9d3;fill-opacity:1;fill-rule:evenodd;stroke:#88c9d3;stroke-width:1pt;stroke-opacity:1"
+         style="fill:#3c31d4;fill-opacity:1;fill-rule:evenodd;stroke:#3c31d4;stroke-width:1pt;stroke-opacity:1"
          transform="matrix(0.4,0,0,0.4,4,0)" />
     </marker>
     <style
@@ -226,7 +226,7 @@
      d="M 38.173076,33.783024 Z"
      id="path11"
      inkscape:connector-curvature="0"
-     style="fill:#00deb6;stroke:#f7f7f7;stroke-width:1;stroke-miterlimit:8.69565201;stroke-dasharray:none;stroke-opacity:1" />
+     style="fill:#3c31d4;stroke:#f7f7f7;stroke-width:1;stroke-miterlimit:8.69565201;stroke-dasharray:none;stroke-opacity:1" />
   <text
      class="cls-3"
      id="text13"
@@ -503,13 +503,13 @@
      d="M 38.173076,33.783024 Z"
      id="path171"
      inkscape:connector-curvature="0"
-     style="fill:#00deb6;stroke:#f7f7f7;stroke-width:1;stroke-miterlimit:8.69565201;stroke-dasharray:none;stroke-opacity:1" />
+     style="fill:#3c31d4;stroke:#f7f7f7;stroke-width:1;stroke-miterlimit:8.69565201;stroke-dasharray:none;stroke-opacity:1" />
   <path
      class="cls-2"
      d="M 38.173076,33.783024 Z"
      id="path197"
      inkscape:connector-curvature="0"
-     style="fill:#00deb6;stroke:#f7f7f7;stroke-width:1;stroke-miterlimit:8.69565201;stroke-dasharray:none;stroke-opacity:1" />
+     style="fill:#3c31d4;stroke:#f7f7f7;stroke-width:1;stroke-miterlimit:8.69565201;stroke-dasharray:none;stroke-opacity:1" />
   <path
      class="cls-8"
      d="M 38.173076,33.783024 Z"
@@ -527,7 +527,7 @@
      cy="266.78198"
      r="43.965218"
      id="circle209-2"
-     style="fill:none;stroke:#88c9d3;stroke-width:6.86956501px;stroke-miterlimit:10;stroke-opacity:1"
+     style="fill:none;stroke:#3c31d4;stroke-width:6.86956501px;stroke-miterlimit:10;stroke-opacity:1"
      inkscape:transform-center-x="-10.602231"
      inkscape:transform-center-y="145.53972" />
   <circle
@@ -576,7 +576,7 @@
        style="font-style:normal;font-variant:normal;font-weight:bold;font-stretch:normal;font-size:16.5px;line-height:125%;font-family:Roboto;-inkscape-font-specification:'Roboto, Bold';text-align:start;writing-mode:lr-tb;text-anchor:start">Company 3</tspan>
   </text>
   <path
-     style="fill:none;fill-rule:evenodd;stroke:#88c9d3;stroke-width:1.44000006;stroke-linecap:butt;stroke-linejoin:miter;stroke-miterlimit:4;stroke-dasharray:none;stroke-opacity:1;marker-start:url(#Arrow1Mstart-2-2)"
+     style="fill:none;fill-rule:evenodd;stroke:#3c31d4;stroke-width:1.44000006;stroke-linecap:butt;stroke-linejoin:miter;stroke-miterlimit:4;stroke-dasharray:none;stroke-opacity:1;marker-start:url(#Arrow1Mstart-2-2)"
      d="m 408.82343,139.3324 0,81.08954 0,0"
      id="path12354-2-9"
      inkscape:connector-curvature="0" />
@@ -586,7 +586,7 @@
      cy="267.673"
      r="43.965218"
      id="circle209-2-9"
-     style="fill:none;stroke:#88c9d3;stroke-width:6.86956501px;stroke-miterlimit:10;stroke-opacity:1"
+     style="fill:none;stroke:#3c31d4;stroke-width:6.86956501px;stroke-miterlimit:10;stroke-opacity:1"
      inkscape:transform-center-x="-10.602232"
      inkscape:transform-center-y="145.53972" />
   <circle
@@ -597,7 +597,7 @@
      style="fill:none;stroke:#b2b3b9;stroke-width:1.86953247;stroke-miterlimit:10;stroke-dasharray:none;stroke-opacity:1"
      r="46.465233" />
   <path
-     style="fill:none;fill-rule:evenodd;stroke:#88c9d3;stroke-width:1.44000006;stroke-linecap:butt;stroke-linejoin:miter;stroke-miterlimit:4;stroke-dasharray:none;stroke-opacity:1;marker-start:url(#Arrow1Mstart-2-2-9)"
+     style="fill:none;fill-rule:evenodd;stroke:#3c31d4;stroke-width:1.44000006;stroke-linecap:butt;stroke-linejoin:miter;stroke-miterlimit:4;stroke-dasharray:none;stroke-opacity:1;marker-start:url(#Arrow1Mstart-2-2-9)"
      d="m 77.623436,138.31719 0,81.08953 0,0"
      id="path12354-2-9-9"
      inkscape:connector-curvature="0" />

--- a/docs/_assets/Diag2-simpleInd.svg
+++ b/docs/_assets/Diag2-simpleInd.svg
@@ -70,7 +70,7 @@
       <path
          id="path4371"
          d="M 0,0 5,-5 -12.5,0 5,5 0,0 Z"
-         style="fill:#00deb6;fill-opacity:1;fill-rule:evenodd;stroke:#00deb6;stroke-width:1pt;stroke-opacity:1"
+         style="fill:#3c31d4;fill-opacity:1;fill-rule:evenodd;stroke:#3c31d4;stroke-width:1pt;stroke-opacity:1"
          transform="matrix(-0.8,0,0,-0.8,-10,0)"
          inkscape:connector-curvature="0" />
     </marker>
@@ -85,7 +85,7 @@
       <path
          id="path4377"
          d="M 0,0 5,-5 -12.5,0 5,5 0,0 Z"
-         style="fill:#00deb6;fill-opacity:1;fill-rule:evenodd;stroke:#00deb6;stroke-width:1pt;stroke-opacity:1"
+         style="fill:#3c31d4;fill-opacity:1;fill-rule:evenodd;stroke:#3c31d4;stroke-width:1pt;stroke-opacity:1"
          transform="matrix(-0.4,0,0,-0.4,-4,0)"
          inkscape:connector-curvature="0" />
     </marker>
@@ -100,12 +100,12 @@
       <path
          id="path4374"
          d="M 0,0 5,-5 -12.5,0 5,5 0,0 Z"
-         style="fill:#88c9d3;fill-opacity:1;fill-rule:evenodd;stroke:#88c9d3;stroke-width:1pt;stroke-opacity:1"
+         style="fill:#3c31d4;fill-opacity:1;fill-rule:evenodd;stroke:#3c31d4;stroke-width:1pt;stroke-opacity:1"
          transform="matrix(0.4,0,0,0.4,4,0)"
          inkscape:connector-curvature="0" />
     </marker>
     <style
-       id="style5">.cls-1,.cls-10,.cls-11,.cls-7,.cls-8{fill:none;}.cls-1,.cls-11{stroke:#00deb6;}.cls-1,.cls-10,.cls-11,.cls-7{stroke-miterlimit:10;}.cls-2{fill:#00deb6;}.cls-3{font-size:16px;fill:#262737;}.cls-12,.cls-3{font-family:HKGrotesk-SemiBold, HK Grotesk;font-weight:700;}.cls-4{letter-spacing:-0.03em;}.cls-5{letter-spacing:-0.02em;}.cls-6{letter-spacing:0em;}.cls-7{stroke:#262737;}.cls-11,.cls-7{stroke-width:5px;}.cls-9{letter-spacing:-0.01em;}.cls-10{stroke:#e6e6e6;}.cls-12{font-size:12px;fill:gray;}.cls-13{letter-spacing:-0.03em;}.cls-14{letter-spacing:-0.01em;}.cls-15{letter-spacing:-0.02em;}.cls-16{letter-spacing:0em;}.cls-17{letter-spacing:0em;}.cls-18{letter-spacing:0em;}</style>
+       id="style5">.cls-1,.cls-10,.cls-11,.cls-7,.cls-8{fill:none;}.cls-1,.cls-11{stroke:#3c31d4;}.cls-1,.cls-10,.cls-11,.cls-7{stroke-miterlimit:10;}.cls-2{fill:#3c31d4;}.cls-3{font-size:16px;fill:#262737;}.cls-12,.cls-3{font-family:HKGrotesk-SemiBold, HK Grotesk;font-weight:700;}.cls-4{letter-spacing:-0.03em;}.cls-5{letter-spacing:-0.02em;}.cls-6{letter-spacing:0em;}.cls-7{stroke:#262737;}.cls-11,.cls-7{stroke-width:5px;}.cls-9{letter-spacing:-0.01em;}.cls-10{stroke:#e6e6e6;}.cls-12{font-size:12px;fill:gray;}.cls-13{letter-spacing:-0.03em;}.cls-14{letter-spacing:-0.01em;}.cls-15{letter-spacing:-0.02em;}.cls-16{letter-spacing:0em;}.cls-17{letter-spacing:0em;}.cls-18{letter-spacing:0em;}</style>
     <marker
        inkscape:stockid="Arrow1Mstart"
        orient="auto"
@@ -118,7 +118,7 @@
          inkscape:connector-curvature="0"
          id="path4374-0"
          d="M 0,0 5,-5 -12.5,0 5,5 0,0 Z"
-         style="fill:#88c9d3;fill-opacity:1;fill-rule:evenodd;stroke:#88c9d3;stroke-width:1pt;stroke-opacity:1"
+         style="fill:#3c31d4;fill-opacity:1;fill-rule:evenodd;stroke:#3c31d4;stroke-width:1pt;stroke-opacity:1"
          transform="matrix(0.4,0,0,0.4,4,0)" />
     </marker>
     <clipPath
@@ -153,7 +153,7 @@
      d="M 30,33 Z"
      id="path11"
      inkscape:connector-curvature="0"
-     style="fill:#00deb6" />
+     style="fill:#3c31d4" />
   <text
      class="cls-3"
      id="text13"
@@ -307,43 +307,43 @@
      d="m 30,33 0,0"
      id="path79"
      inkscape:connector-curvature="0"
-     style="fill:none;stroke:#00deb6;stroke-width:6px;stroke-miterlimit:10" />
+     style="fill:none;stroke:#3c31d4;stroke-width:6px;stroke-miterlimit:10" />
   <path
      class="cls-11"
      d="m 30,33 0,0"
      id="path85"
      inkscape:connector-curvature="0"
-     style="fill:none;stroke:#00deb6;stroke-width:6px;stroke-miterlimit:10" />
+     style="fill:none;stroke:#3c31d4;stroke-width:6px;stroke-miterlimit:10" />
   <path
      class="cls-11"
      d="m 30,33 0,0"
      id="path87"
      inkscape:connector-curvature="0"
-     style="fill:none;stroke:#00deb6;stroke-width:6px;stroke-miterlimit:10" />
+     style="fill:none;stroke:#3c31d4;stroke-width:6px;stroke-miterlimit:10" />
   <path
      class="cls-11"
      d="m 30,33 0,0"
      id="path89"
      inkscape:connector-curvature="0"
-     style="fill:none;stroke:#00deb6;stroke-width:6px;stroke-miterlimit:10" />
+     style="fill:none;stroke:#3c31d4;stroke-width:6px;stroke-miterlimit:10" />
   <path
      class="cls-11"
      d="m 30,33 0,0"
      id="path91"
      inkscape:connector-curvature="0"
-     style="fill:none;stroke:#00deb6;stroke-width:6px;stroke-miterlimit:10" />
+     style="fill:none;stroke:#3c31d4;stroke-width:6px;stroke-miterlimit:10" />
   <path
      class="cls-11"
      d="m 30,33 0,0"
      id="path93"
      inkscape:connector-curvature="0"
-     style="fill:none;stroke:#00deb6;stroke-width:6px;stroke-miterlimit:10" />
+     style="fill:none;stroke:#3c31d4;stroke-width:6px;stroke-miterlimit:10" />
   <path
      class="cls-11"
      d="m 30,33 0,0"
      id="path95"
      inkscape:connector-curvature="0"
-     style="fill:none;stroke:#00deb6;stroke-width:6px;stroke-miterlimit:10" />
+     style="fill:none;stroke:#3c31d4;stroke-width:6px;stroke-miterlimit:10" />
   <path
      class="cls-10"
      d="m 30,33 0,0"
@@ -434,7 +434,7 @@
      d="M 30,33 Z"
      id="path171"
      inkscape:connector-curvature="0"
-     style="fill:#00deb6" />
+     style="fill:#3c31d4" />
   <text
      class="cls-12"
      id="text173"
@@ -452,7 +452,7 @@
      d="M 30,33 Z"
      id="path197"
      inkscape:connector-curvature="0"
-     style="fill:#00deb6" />
+     style="fill:#3c31d4" />
   <text
      class="cls-3"
      id="text199"
@@ -477,12 +477,12 @@
      id="path213"
      inkscape:connector-curvature="0" />
   <path
-     style="fill:none;fill-rule:evenodd;stroke:#88c9d3;stroke-width:1.484869;stroke-linecap:butt;stroke-linejoin:miter;stroke-miterlimit:4;stroke-dasharray:none;stroke-opacity:1;marker-start:url(#Arrow1Mstart)"
+     style="fill:none;fill-rule:evenodd;stroke:#3c31d4;stroke-width:1.484869;stroke-linecap:butt;stroke-linejoin:miter;stroke-miterlimit:4;stroke-dasharray:none;stroke-opacity:1;marker-start:url(#Arrow1Mstart)"
      d="m 112.65036,137.54041 0,85.41086 0,0"
      id="path12354"
      inkscape:connector-curvature="0" />
   <path
-     style="fill:none;fill-rule:evenodd;stroke:#88c9d3;stroke-width:1.44000006;stroke-linecap:butt;stroke-linejoin:miter;stroke-miterlimit:4;stroke-dasharray:none;stroke-opacity:1;marker-start:url(#Arrow1Mstart-2)"
+     style="fill:none;fill-rule:evenodd;stroke:#3c31d4;stroke-width:1.44000006;stroke-linecap:butt;stroke-linejoin:miter;stroke-miterlimit:4;stroke-dasharray:none;stroke-opacity:1;marker-start:url(#Arrow1Mstart-2)"
      d="m 112.65036,316.14939 0,81.08953 0,0"
      id="path12354-2"
      inkscape:connector-curvature="0" />
@@ -492,7 +492,7 @@
      cy="444.48996"
      r="43.965218"
      id="circle209-2"
-     style="fill:none;stroke:#88c9d3;stroke-width:6.86999989;stroke-miterlimit:10;stroke-dasharray:none;stroke-opacity:1"
+     style="fill:none;stroke:#3c31d4;stroke-width:6.86999989;stroke-miterlimit:10;stroke-dasharray:none;stroke-opacity:1"
      inkscape:transform-center-x="-10.602233"
      inkscape:transform-center-y="145.53973" />
   <ellipse
@@ -508,7 +508,7 @@
   <path
      class="cls-11"
      id="circle209-7-4"
-     style="fill:none;stroke:#88c9d3;stroke-width:6.32999992;stroke-linecap:round;stroke-miterlimit:10;stroke-dasharray:none;stroke-opacity:1"
+     style="fill:none;stroke:#3c31d4;stroke-width:6.32999992;stroke-linecap:round;stroke-miterlimit:10;stroke-dasharray:none;stroke-opacity:1"
      inkscape:transform-center-x="-10.662374"
      inkscape:transform-center-y="141.00009"
      sodipodi:type="arc"

--- a/docs/_assets/Diag3-splitContr.svg
+++ b/docs/_assets/Diag3-splitContr.svg
@@ -73,7 +73,7 @@
       <path
          id="path4371"
          d="M 0,0 5,-5 -12.5,0 5,5 0,0 Z"
-         style="fill:#00deb6;fill-opacity:1;fill-rule:evenodd;stroke:#00deb6;stroke-width:1pt;stroke-opacity:1"
+         style="fill:#3c31d4;fill-opacity:1;fill-rule:evenodd;stroke:#3c31d4;stroke-width:1pt;stroke-opacity:1"
          transform="matrix(-0.8,0,0,-0.8,-10,0)"
          inkscape:connector-curvature="0" />
     </marker>
@@ -88,7 +88,7 @@
       <path
          id="path4377"
          d="M 0,0 5,-5 -12.5,0 5,5 0,0 Z"
-         style="fill:#00deb6;fill-opacity:1;fill-rule:evenodd;stroke:#00deb6;stroke-width:1pt;stroke-opacity:1"
+         style="fill:#3c31d4;fill-opacity:1;fill-rule:evenodd;stroke:#3c31d4;stroke-width:1pt;stroke-opacity:1"
          transform="matrix(-0.4,0,0,-0.4,-4,0)"
          inkscape:connector-curvature="0" />
     </marker>
@@ -103,12 +103,12 @@
       <path
          id="path4374"
          d="M 0,0 5,-5 -12.5,0 5,5 0,0 Z"
-         style="fill:#88c9d3;fill-opacity:1;fill-rule:evenodd;stroke:#88c9d3;stroke-width:1pt;stroke-opacity:1"
+         style="fill:#3c31d4;fill-opacity:1;fill-rule:evenodd;stroke:#3c31d4;stroke-width:1pt;stroke-opacity:1"
          transform="matrix(0.4,0,0,0.4,4,0)"
          inkscape:connector-curvature="0" />
     </marker>
     <style
-       id="style5">.cls-1,.cls-10,.cls-11,.cls-7,.cls-8{fill:none;}.cls-1,.cls-11{stroke:#00deb6;}.cls-1,.cls-10,.cls-11,.cls-7{stroke-miterlimit:10;}.cls-2{fill:#00deb6;}.cls-3{font-size:16px;fill:#262737;}.cls-12,.cls-3{font-family:HKGrotesk-SemiBold, HK Grotesk;font-weight:700;}.cls-4{letter-spacing:-0.03em;}.cls-5{letter-spacing:-0.02em;}.cls-6{letter-spacing:0em;}.cls-7{stroke:#262737;}.cls-11,.cls-7{stroke-width:5px;}.cls-9{letter-spacing:-0.01em;}.cls-10{stroke:#e6e6e6;}.cls-12{font-size:12px;fill:gray;}.cls-13{letter-spacing:-0.03em;}.cls-14{letter-spacing:-0.01em;}.cls-15{letter-spacing:-0.02em;}.cls-16{letter-spacing:0em;}.cls-17{letter-spacing:0em;}.cls-18{letter-spacing:0em;}</style>
+       id="style5">.cls-1,.cls-10,.cls-11,.cls-7,.cls-8{fill:none;}.cls-1,.cls-11{stroke:#3c31d4;}.cls-1,.cls-10,.cls-11,.cls-7{stroke-miterlimit:10;}.cls-2{fill:#3c31d4;}.cls-3{font-size:16px;fill:#262737;}.cls-12,.cls-3{font-family:HKGrotesk-SemiBold, HK Grotesk;font-weight:700;}.cls-4{letter-spacing:-0.03em;}.cls-5{letter-spacing:-0.02em;}.cls-6{letter-spacing:0em;}.cls-7{stroke:#262737;}.cls-11,.cls-7{stroke-width:5px;}.cls-9{letter-spacing:-0.01em;}.cls-10{stroke:#e6e6e6;}.cls-12{font-size:12px;fill:gray;}.cls-13{letter-spacing:-0.03em;}.cls-14{letter-spacing:-0.01em;}.cls-15{letter-spacing:-0.02em;}.cls-16{letter-spacing:0em;}.cls-17{letter-spacing:0em;}.cls-18{letter-spacing:0em;}</style>
     <marker
        inkscape:stockid="Arrow1Mstart"
        orient="auto"
@@ -121,7 +121,7 @@
          inkscape:connector-curvature="0"
          id="path4374-0"
          d="M 0,0 5,-5 -12.5,0 5,5 0,0 Z"
-         style="fill:#00deb6;fill-opacity:1;fill-rule:evenodd;stroke:#00deb6;stroke-width:1pt;stroke-opacity:1"
+         style="fill:#3c31d4;fill-opacity:1;fill-rule:evenodd;stroke:#3c31d4;stroke-width:1pt;stroke-opacity:1"
          transform="matrix(0.4,0,0,0.4,4,0)" />
     </marker>
     <clipPath
@@ -159,7 +159,7 @@
       <path
          id="path4374-9"
          d="M 0,0 5,-5 -12.5,0 5,5 0,0 Z"
-         style="fill:#00deb6;fill-opacity:1;fill-rule:evenodd;stroke:#00deb6;stroke-width:1pt;stroke-opacity:1"
+         style="fill:#3c31d4;fill-opacity:1;fill-rule:evenodd;stroke:#3c31d4;stroke-width:1pt;stroke-opacity:1"
          transform="matrix(0.4,0,0,0.4,4,0)"
          inkscape:connector-curvature="0" />
     </marker>
@@ -182,7 +182,7 @@
       <path
          id="path4374-3"
          d="M 0,0 5,-5 -12.5,0 5,5 0,0 Z"
-         style="fill:#00deb6;fill-opacity:1;fill-rule:evenodd;stroke:#00deb6;stroke-width:1pt;stroke-opacity:1"
+         style="fill:#3c31d4;fill-opacity:1;fill-rule:evenodd;stroke:#3c31d4;stroke-width:1pt;stroke-opacity:1"
          transform="matrix(0.4,0,0,0.4,4,0)"
          inkscape:connector-curvature="0" />
     </marker>
@@ -197,7 +197,7 @@
       <path
          id="path4374-4"
          d="M 0,0 5,-5 -12.5,0 5,5 0,0 Z"
-         style="fill:#88c9d3;fill-opacity:1;fill-rule:evenodd;stroke:#88c9d3;stroke-width:1pt;stroke-opacity:1"
+         style="fill:#3c31d4;fill-opacity:1;fill-rule:evenodd;stroke:#3c31d4;stroke-width:1pt;stroke-opacity:1"
          transform="matrix(0.4,0,0,0.4,4,0)"
          inkscape:connector-curvature="0" />
     </marker>
@@ -219,7 +219,7 @@
        style="font-style:normal;font-variant:normal;font-weight:bold;font-stretch:normal;font-size:16.50418663px;line-height:125%;font-family:Roboto;-inkscape-font-specification:'Roboto, Bold';text-align:start;writing-mode:lr-tb;text-anchor:start">Company 2</tspan>
   </text>
   <path
-     style="fill:none;fill-rule:evenodd;stroke:#88c9d3;stroke-width:1.23739088;stroke-linecap:butt;stroke-linejoin:miter;stroke-miterlimit:4;stroke-dasharray:none;stroke-opacity:1;marker-start:url(#Arrow1Mstart)"
+     style="fill:none;fill-rule:evenodd;stroke:#3c31d4;stroke-width:1.23739088;stroke-linecap:butt;stroke-linejoin:miter;stroke-miterlimit:4;stroke-dasharray:none;stroke-opacity:1;marker-start:url(#Arrow1Mstart)"
      d="m 419.22587,127.94399 0,85.45421 0,0 0,43.95568 -37.10635,0"
      id="path12354"
      inkscape:connector-curvature="0" />
@@ -236,7 +236,7 @@
   <path
      class="cls-11"
      id="circle209-7-4"
-     style="fill:none;stroke:#88c9d3;stroke-width:5.2750001;stroke-linecap:round;stroke-miterlimit:10;stroke-dasharray:none;stroke-opacity:1"
+     style="fill:none;stroke:#3c31d4;stroke-width:5.2750001;stroke-linecap:round;stroke-miterlimit:10;stroke-dasharray:none;stroke-opacity:1"
      inkscape:transform-center-x="10.66237"
      inkscape:transform-center-y="141.07165"
      sodipodi:type="arc"
@@ -260,7 +260,7 @@
   <ellipse
      class="cls-11"
      id="circle209-7-4-3-8"
-     style="fill:none;stroke:#88c9d3;stroke-width:1.55799997;stroke-linecap:round;stroke-miterlimit:10;stroke-dasharray:none;stroke-opacity:1"
+     style="fill:none;stroke:#3c31d4;stroke-width:1.55799997;stroke-linecap:round;stroke-miterlimit:10;stroke-dasharray:none;stroke-opacity:1"
      inkscape:transform-center-x="-7.4064841"
      inkscape:transform-center-y="101.72215"
      cx="338.40982"
@@ -270,7 +270,7 @@
   <path
      class="cls-11"
      id="circle209-7-4-3"
-     style="fill:none;stroke:#88c9d3;stroke-width:5.2750001;stroke-linecap:round;stroke-miterlimit:10;stroke-dasharray:none;stroke-opacity:1"
+     style="fill:none;stroke:#3c31d4;stroke-width:5.2750001;stroke-linecap:round;stroke-miterlimit:10;stroke-dasharray:none;stroke-opacity:1"
      inkscape:transform-center-x="-7.4064842"
      inkscape:transform-center-y="101.72215"
      sodipodi:type="arc"
@@ -291,7 +291,7 @@
      rx="46.465233"
      ry="46.488819" />
   <path
-     style="fill:none;fill-rule:evenodd;stroke:#88c9d3;stroke-width:1.23739088;stroke-linecap:butt;stroke-linejoin:round;stroke-miterlimit:4;stroke-dasharray:none;stroke-opacity:1;marker-start:url(#Arrow1Mstart-84)"
+     style="fill:none;fill-rule:evenodd;stroke:#3c31d4;stroke-width:1.23739088;stroke-linecap:butt;stroke-linejoin:round;stroke-miterlimit:4;stroke-dasharray:none;stroke-opacity:1;marker-start:url(#Arrow1Mstart-84)"
      d="m 253.62589,127.94385 0,85.4542 0,0 0,44.79809 53.57038,0 0,0"
      id="path12354-8"
      inkscape:connector-curvature="0" />

--- a/docs/_assets/Diag4-complexInvolve.svg
+++ b/docs/_assets/Diag4-complexInvolve.svg
@@ -73,7 +73,7 @@
       <path
          id="path4371"
          d="M 0,0 5,-5 -12.5,0 5,5 0,0 Z"
-         style="fill:#00deb6;fill-opacity:1;fill-rule:evenodd;stroke:#00deb6;stroke-width:1pt;stroke-opacity:1"
+         style="fill:#3c31d4;fill-opacity:1;fill-rule:evenodd;stroke:#3c31d4;stroke-width:1pt;stroke-opacity:1"
          transform="matrix(-0.8,0,0,-0.8,-10,0)"
          inkscape:connector-curvature="0" />
     </marker>
@@ -88,7 +88,7 @@
       <path
          id="path4377"
          d="M 0,0 5,-5 -12.5,0 5,5 0,0 Z"
-         style="fill:#00deb6;fill-opacity:1;fill-rule:evenodd;stroke:#00deb6;stroke-width:1pt;stroke-opacity:1"
+         style="fill:#3c31d4;fill-opacity:1;fill-rule:evenodd;stroke:#3c31d4;stroke-width:1pt;stroke-opacity:1"
          transform="matrix(-0.4,0,0,-0.4,-4,0)"
          inkscape:connector-curvature="0" />
     </marker>
@@ -103,12 +103,12 @@
       <path
          id="path4374"
          d="M 0,0 5,-5 -12.5,0 5,5 0,0 Z"
-         style="fill:#88c9d3;fill-opacity:1;fill-rule:evenodd;stroke:#88c9d3;stroke-width:1pt;stroke-opacity:1"
+         style="fill:#3c31d4;fill-opacity:1;fill-rule:evenodd;stroke:#3c31d4;stroke-width:1pt;stroke-opacity:1"
          transform="matrix(0.4,0,0,0.4,4,0)"
          inkscape:connector-curvature="0" />
     </marker>
     <style
-       id="style5">.cls-1,.cls-10,.cls-11,.cls-7,.cls-8{fill:none;}.cls-1,.cls-11{stroke:#00deb6;}.cls-1,.cls-10,.cls-11,.cls-7{stroke-miterlimit:10;}.cls-2{fill:#00deb6;}.cls-3{font-size:16px;fill:#262737;}.cls-12,.cls-3{font-family:HKGrotesk-SemiBold, HK Grotesk;font-weight:700;}.cls-4{letter-spacing:-0.03em;}.cls-5{letter-spacing:-0.02em;}.cls-6{letter-spacing:0em;}.cls-7{stroke:#262737;}.cls-11,.cls-7{stroke-width:5px;}.cls-9{letter-spacing:-0.01em;}.cls-10{stroke:#e6e6e6;}.cls-12{font-size:12px;fill:gray;}.cls-13{letter-spacing:-0.03em;}.cls-14{letter-spacing:-0.01em;}.cls-15{letter-spacing:-0.02em;}.cls-16{letter-spacing:0em;}.cls-17{letter-spacing:0em;}.cls-18{letter-spacing:0em;}</style>
+       id="style5">.cls-1,.cls-10,.cls-11,.cls-7,.cls-8{fill:none;}.cls-1,.cls-11{stroke:#3c31d4;}.cls-1,.cls-10,.cls-11,.cls-7{stroke-miterlimit:10;}.cls-2{fill:#3c31d4;}.cls-3{font-size:16px;fill:#262737;}.cls-12,.cls-3{font-family:HKGrotesk-SemiBold, HK Grotesk;font-weight:700;}.cls-4{letter-spacing:-0.03em;}.cls-5{letter-spacing:-0.02em;}.cls-6{letter-spacing:0em;}.cls-7{stroke:#262737;}.cls-11,.cls-7{stroke-width:5px;}.cls-9{letter-spacing:-0.01em;}.cls-10{stroke:#e6e6e6;}.cls-12{font-size:12px;fill:gray;}.cls-13{letter-spacing:-0.03em;}.cls-14{letter-spacing:-0.01em;}.cls-15{letter-spacing:-0.02em;}.cls-16{letter-spacing:0em;}.cls-17{letter-spacing:0em;}.cls-18{letter-spacing:0em;}</style>
     <marker
        inkscape:stockid="Arrow1Mstart"
        orient="auto"
@@ -121,7 +121,7 @@
          inkscape:connector-curvature="0"
          id="path4374-0"
          d="M 0,0 5,-5 -12.5,0 5,5 0,0 Z"
-         style="fill:#88c9d3;fill-opacity:1;fill-rule:evenodd;stroke:#88c9d3;stroke-width:1pt;stroke-opacity:1"
+         style="fill:#3c31d4;fill-opacity:1;fill-rule:evenodd;stroke:#3c31d4;stroke-width:1pt;stroke-opacity:1"
          transform="matrix(0.4,0,0,0.4,4,0)" />
     </marker>
     <clipPath
@@ -184,7 +184,7 @@
          inkscape:connector-curvature="0"
          id="path4374-0-0"
          d="M 0,0 5,-5 -12.5,0 5,5 0,0 Z"
-         style="fill:#00deb6;fill-opacity:1;fill-rule:evenodd;stroke:#00deb6;stroke-width:1pt;stroke-opacity:1"
+         style="fill:#3c31d4;fill-opacity:1;fill-rule:evenodd;stroke:#3c31d4;stroke-width:1pt;stroke-opacity:1"
          transform="matrix(0.4,0,0,0.4,4,0)" />
     </marker>
     <marker
@@ -198,7 +198,7 @@
       <path
          id="path4374-9"
          d="M 0,0 5,-5 -12.5,0 5,5 0,0 Z"
-         style="fill:#00deb6;fill-opacity:1;fill-rule:evenodd;stroke:#00deb6;stroke-width:1pt;stroke-opacity:1"
+         style="fill:#3c31d4;fill-opacity:1;fill-rule:evenodd;stroke:#3c31d4;stroke-width:1pt;stroke-opacity:1"
          transform="matrix(0.4,0,0,0.4,4,0)"
          inkscape:connector-curvature="0" />
     </marker>
@@ -214,7 +214,7 @@
          inkscape:connector-curvature="0"
          id="path4374-0-9"
          d="M 0,0 5,-5 -12.5,0 5,5 0,0 Z"
-         style="fill:#88c9d3;fill-opacity:1;fill-rule:evenodd;stroke:#88c9d3;stroke-width:1pt;stroke-opacity:1"
+         style="fill:#3c31d4;fill-opacity:1;fill-rule:evenodd;stroke:#3c31d4;stroke-width:1pt;stroke-opacity:1"
          transform="matrix(0.4,0,0,0.4,4,0)" />
     </marker>
   </defs>
@@ -232,7 +232,7 @@
      d="M 2.8139877,33.871918 Z"
      id="path11"
      inkscape:connector-curvature="0"
-     style="fill:#00deb6" />
+     style="fill:#3c31d4" />
   <text
      class="cls-3"
      id="text13"
@@ -386,43 +386,43 @@
      d="m 2.8139877,33.871918 0,0"
      id="path79"
      inkscape:connector-curvature="0"
-     style="fill:none;stroke:#00deb6;stroke-width:5px;stroke-miterlimit:10" />
+     style="fill:none;stroke:#3c31d4;stroke-width:5px;stroke-miterlimit:10" />
   <path
      class="cls-11"
      d="m 2.8139877,33.871918 0,0"
      id="path85"
      inkscape:connector-curvature="0"
-     style="fill:none;stroke:#00deb6;stroke-width:5px;stroke-miterlimit:10" />
+     style="fill:none;stroke:#3c31d4;stroke-width:5px;stroke-miterlimit:10" />
   <path
      class="cls-11"
      d="m 2.8139877,33.871918 0,0"
      id="path87"
      inkscape:connector-curvature="0"
-     style="fill:none;stroke:#00deb6;stroke-width:5px;stroke-miterlimit:10" />
+     style="fill:none;stroke:#3c31d4;stroke-width:5px;stroke-miterlimit:10" />
   <path
      class="cls-11"
      d="m 2.8139877,33.871918 0,0"
      id="path89"
      inkscape:connector-curvature="0"
-     style="fill:none;stroke:#00deb6;stroke-width:5px;stroke-miterlimit:10" />
+     style="fill:none;stroke:#3c31d4;stroke-width:5px;stroke-miterlimit:10" />
   <path
      class="cls-11"
      d="m 2.8139877,33.871918 0,0"
      id="path91"
      inkscape:connector-curvature="0"
-     style="fill:none;stroke:#00deb6;stroke-width:5px;stroke-miterlimit:10" />
+     style="fill:none;stroke:#3c31d4;stroke-width:5px;stroke-miterlimit:10" />
   <path
      class="cls-11"
      d="m 2.8139877,33.871918 0,0"
      id="path93"
      inkscape:connector-curvature="0"
-     style="fill:none;stroke:#00deb6;stroke-width:5px;stroke-miterlimit:10" />
+     style="fill:none;stroke:#3c31d4;stroke-width:5px;stroke-miterlimit:10" />
   <path
      class="cls-11"
      d="m 2.8139877,33.871918 0,0"
      id="path95"
      inkscape:connector-curvature="0"
-     style="fill:none;stroke:#00deb6;stroke-width:5px;stroke-miterlimit:10" />
+     style="fill:none;stroke:#3c31d4;stroke-width:5px;stroke-miterlimit:10" />
   <path
      class="cls-10"
      d="m 2.8139877,33.871918 0,0"
@@ -500,13 +500,13 @@
      d="M 2.8139877,33.871918 Z"
      id="path171"
      inkscape:connector-curvature="0"
-     style="fill:#00deb6" />
+     style="fill:#3c31d4" />
   <path
      class="cls-2"
      d="M 2.8139877,33.871918 Z"
      id="path197"
      inkscape:connector-curvature="0"
-     style="fill:#00deb6" />
+     style="fill:#3c31d4" />
   <path
      class="cls-8"
      d="M 2.8139877,33.871918 Z"
@@ -518,7 +518,7 @@
      id="path213"
      inkscape:connector-curvature="0" />
   <path
-     style="fill:none;fill-rule:evenodd;stroke:#88c9d3;stroke-width:1.27847636;stroke-linecap:butt;stroke-linejoin:miter;stroke-miterlimit:4;stroke-dasharray:none;stroke-opacity:1;marker-start:url(#Arrow1Mstart)"
+     style="fill:none;fill-rule:evenodd;stroke:#3c31d4;stroke-width:1.27847636;stroke-linecap:butt;stroke-linejoin:miter;stroke-miterlimit:4;stroke-dasharray:none;stroke-opacity:1;marker-start:url(#Arrow1Mstart)"
      d="m 71.689288,122.1435 0,75.98071 0,0"
      id="path12354"
      inkscape:connector-curvature="0" />
@@ -534,7 +534,7 @@
   <path
      class="cls-11"
      id="circle209-7-4"
-     style="fill:none;stroke:#88c9d3;stroke-width:5.7249999;stroke-linecap:round;stroke-miterlimit:10;stroke-dasharray:none;stroke-opacity:1"
+     style="fill:none;stroke:#3c31d4;stroke-width:5.7249999;stroke-linecap:round;stroke-miterlimit:10;stroke-dasharray:none;stroke-opacity:1"
      inkscape:transform-center-x="-6.8530753"
      inkscape:transform-center-y="94.074053"
      sodipodi:type="arc"
@@ -565,7 +565,7 @@
      d="M 356.81399,33.871921 Z"
      id="path11-6"
      inkscape:connector-curvature="0"
-     style="fill:#00deb6" />
+     style="fill:#3c31d4" />
   <text
      class="cls-3"
      id="text13-7"
@@ -706,43 +706,43 @@
      d="m 356.81399,33.871921 0,0"
      id="path79-9"
      inkscape:connector-curvature="0"
-     style="fill:none;stroke:#00deb6;stroke-width:5px;stroke-miterlimit:10" />
+     style="fill:none;stroke:#3c31d4;stroke-width:5px;stroke-miterlimit:10" />
   <path
      class="cls-11"
      d="m 356.81399,33.871921 0,0"
      id="path85-7"
      inkscape:connector-curvature="0"
-     style="fill:none;stroke:#00deb6;stroke-width:5px;stroke-miterlimit:10" />
+     style="fill:none;stroke:#3c31d4;stroke-width:5px;stroke-miterlimit:10" />
   <path
      class="cls-11"
      d="m 356.81399,33.871921 0,0"
      id="path87-8"
      inkscape:connector-curvature="0"
-     style="fill:none;stroke:#00deb6;stroke-width:5px;stroke-miterlimit:10" />
+     style="fill:none;stroke:#3c31d4;stroke-width:5px;stroke-miterlimit:10" />
   <path
      class="cls-11"
      d="m 356.81399,33.871921 0,0"
      id="path89-3"
      inkscape:connector-curvature="0"
-     style="fill:none;stroke:#00deb6;stroke-width:5px;stroke-miterlimit:10" />
+     style="fill:none;stroke:#3c31d4;stroke-width:5px;stroke-miterlimit:10" />
   <path
      class="cls-11"
      d="m 356.81399,33.871921 0,0"
      id="path91-9"
      inkscape:connector-curvature="0"
-     style="fill:none;stroke:#00deb6;stroke-width:5px;stroke-miterlimit:10" />
+     style="fill:none;stroke:#3c31d4;stroke-width:5px;stroke-miterlimit:10" />
   <path
      class="cls-11"
      d="m 356.81399,33.871921 0,0"
      id="path93-7"
      inkscape:connector-curvature="0"
-     style="fill:none;stroke:#00deb6;stroke-width:5px;stroke-miterlimit:10" />
+     style="fill:none;stroke:#3c31d4;stroke-width:5px;stroke-miterlimit:10" />
   <path
      class="cls-11"
      d="m 356.81399,33.871921 0,0"
      id="path95-2"
      inkscape:connector-curvature="0"
-     style="fill:none;stroke:#00deb6;stroke-width:5px;stroke-miterlimit:10" />
+     style="fill:none;stroke:#3c31d4;stroke-width:5px;stroke-miterlimit:10" />
   <path
      class="cls-10"
      d="m 356.81399,33.871921 0,0"
@@ -820,13 +820,13 @@
      d="M 356.81399,33.871921 Z"
      id="path171-1"
      inkscape:connector-curvature="0"
-     style="fill:#00deb6" />
+     style="fill:#3c31d4" />
   <path
      class="cls-2"
      d="M 356.81399,33.871921 Z"
      id="path197-3"
      inkscape:connector-curvature="0"
-     style="fill:#00deb6" />
+     style="fill:#3c31d4" />
   <text
      class="cls-3"
      id="text199-0"
@@ -862,7 +862,7 @@
   <path
      class="cls-11"
      id="circle209-2-0"
-     style="fill:none;stroke:#88c9d3;stroke-width:5.72463751px;stroke-linecap:round;stroke-miterlimit:10;stroke-opacity:1"
+     style="fill:none;stroke:#3c31d4;stroke-width:5.72463751px;stroke-linecap:round;stroke-miterlimit:10;stroke-opacity:1"
      inkscape:transform-center-x="-8.8351931"
      inkscape:transform-center-y="121.2831"
      sodipodi:type="arc"
@@ -882,7 +882,7 @@
      style="fill:none;stroke:#b2b3b9;stroke-width:1.55799997;stroke-miterlimit:10;stroke-dasharray:none;stroke-opacity:1"
      r="38.721027" />
   <path
-     style="fill:none;fill-rule:evenodd;stroke:#88c9d3;stroke-width:1.20000005;stroke-linecap:butt;stroke-linejoin:miter;stroke-miterlimit:4;stroke-dasharray:none;stroke-opacity:1;marker-start:url(#Arrow1Mstart-2-9)"
+     style="fill:none;fill-rule:evenodd;stroke:#3c31d4;stroke-width:1.20000005;stroke-linecap:butt;stroke-linejoin:miter;stroke-miterlimit:4;stroke-dasharray:none;stroke-opacity:1;marker-start:url(#Arrow1Mstart-2-9)"
      d="m 425.6893,121.18892 0,67.57461 0,0"
      id="path12354-2-8"
      inkscape:connector-curvature="0" />

--- a/docs/_assets/Diag4b-splitContr2.svg
+++ b/docs/_assets/Diag4b-splitContr2.svg
@@ -76,7 +76,7 @@
       <path
          id="path4371"
          d="M 0,0 5,-5 -12.5,0 5,5 0,0 Z"
-         style="fill:#00deb6;fill-opacity:1;fill-rule:evenodd;stroke:#00deb6;stroke-width:1pt;stroke-opacity:1"
+         style="fill:#3c31d4;fill-opacity:1;fill-rule:evenodd;stroke:#3c31d4;stroke-width:1pt;stroke-opacity:1"
          transform="matrix(-0.8,0,0,-0.8,-10,0)"
          inkscape:connector-curvature="0" />
     </marker>
@@ -91,7 +91,7 @@
       <path
          id="path4377"
          d="M 0,0 5,-5 -12.5,0 5,5 0,0 Z"
-         style="fill:#88c9d3;fill-opacity:1;fill-rule:evenodd;stroke:#88c9d3;stroke-width:1pt;stroke-opacity:1"
+         style="fill:#3c31d4;fill-opacity:1;fill-rule:evenodd;stroke:#3c31d4;stroke-width:1pt;stroke-opacity:1"
          transform="matrix(-0.4,0,0,-0.4,-4,0)"
          inkscape:connector-curvature="0" />
     </marker>
@@ -106,12 +106,12 @@
       <path
          id="path4374"
          d="M 0,0 5,-5 -12.5,0 5,5 0,0 Z"
-         style="fill:#88c9d3;fill-opacity:1;fill-rule:evenodd;stroke:#88c9d3;stroke-width:1pt;stroke-opacity:1"
+         style="fill:#3c31d4;fill-opacity:1;fill-rule:evenodd;stroke:#3c31d4;stroke-width:1pt;stroke-opacity:1"
          transform="matrix(0.4,0,0,0.4,4,0)"
          inkscape:connector-curvature="0" />
     </marker>
     <style
-       id="style5">.cls-1,.cls-10,.cls-11,.cls-7,.cls-8{fill:none;}.cls-1,.cls-11{stroke:#00deb6;}.cls-1,.cls-10,.cls-11,.cls-7{stroke-miterlimit:10;}.cls-2{fill:#00deb6;}.cls-3{font-size:16px;fill:#262737;}.cls-12,.cls-3{font-family:HKGrotesk-SemiBold, HK Grotesk;font-weight:700;}.cls-4{letter-spacing:-0.03em;}.cls-5{letter-spacing:-0.02em;}.cls-6{letter-spacing:0em;}.cls-7{stroke:#262737;}.cls-11,.cls-7{stroke-width:5px;}.cls-9{letter-spacing:-0.01em;}.cls-10{stroke:#e6e6e6;}.cls-12{font-size:12px;fill:gray;}.cls-13{letter-spacing:-0.03em;}.cls-14{letter-spacing:-0.01em;}.cls-15{letter-spacing:-0.02em;}.cls-16{letter-spacing:0em;}.cls-17{letter-spacing:0em;}.cls-18{letter-spacing:0em;}</style>
+       id="style5">.cls-1,.cls-10,.cls-11,.cls-7,.cls-8{fill:none;}.cls-1,.cls-11{stroke:#3c31d4;}.cls-1,.cls-10,.cls-11,.cls-7{stroke-miterlimit:10;}.cls-2{fill:#3c31d4;}.cls-3{font-size:16px;fill:#262737;}.cls-12,.cls-3{font-family:HKGrotesk-SemiBold, HK Grotesk;font-weight:700;}.cls-4{letter-spacing:-0.03em;}.cls-5{letter-spacing:-0.02em;}.cls-6{letter-spacing:0em;}.cls-7{stroke:#262737;}.cls-11,.cls-7{stroke-width:5px;}.cls-9{letter-spacing:-0.01em;}.cls-10{stroke:#e6e6e6;}.cls-12{font-size:12px;fill:gray;}.cls-13{letter-spacing:-0.03em;}.cls-14{letter-spacing:-0.01em;}.cls-15{letter-spacing:-0.02em;}.cls-16{letter-spacing:0em;}.cls-17{letter-spacing:0em;}.cls-18{letter-spacing:0em;}</style>
     <marker
        inkscape:stockid="Arrow1Mstart"
        orient="auto"
@@ -124,7 +124,7 @@
          inkscape:connector-curvature="0"
          id="path4374-0"
          d="M 0,0 5,-5 -12.5,0 5,5 0,0 Z"
-         style="fill:#00deb6;fill-opacity:1;fill-rule:evenodd;stroke:#00deb6;stroke-width:1pt;stroke-opacity:1"
+         style="fill:#3c31d4;fill-opacity:1;fill-rule:evenodd;stroke:#3c31d4;stroke-width:1pt;stroke-opacity:1"
          transform="matrix(0.4,0,0,0.4,4,0)" />
     </marker>
     <clipPath
@@ -162,7 +162,7 @@
       <path
          id="path4374-9"
          d="M 0,0 5,-5 -12.5,0 5,5 0,0 Z"
-         style="fill:#00deb6;fill-opacity:1;fill-rule:evenodd;stroke:#00deb6;stroke-width:1pt;stroke-opacity:1"
+         style="fill:#3c31d4;fill-opacity:1;fill-rule:evenodd;stroke:#3c31d4;stroke-width:1pt;stroke-opacity:1"
          transform="matrix(0.4,0,0,0.4,4,0)"
          inkscape:connector-curvature="0" />
     </marker>
@@ -185,7 +185,7 @@
       <path
          id="path4374-3"
          d="M 0,0 5,-5 -12.5,0 5,5 0,0 Z"
-         style="fill:#00deb6;fill-opacity:1;fill-rule:evenodd;stroke:#00deb6;stroke-width:1pt;stroke-opacity:1"
+         style="fill:#3c31d4;fill-opacity:1;fill-rule:evenodd;stroke:#3c31d4;stroke-width:1pt;stroke-opacity:1"
          transform="matrix(0.4,0,0,0.4,4,0)"
          inkscape:connector-curvature="0" />
     </marker>
@@ -200,7 +200,7 @@
       <path
          id="path4374-4"
          d="M 0,0 5,-5 -12.5,0 5,5 0,0 Z"
-         style="fill:#88c9d3;fill-opacity:1;fill-rule:evenodd;stroke:#88c9d3;stroke-width:1pt;stroke-opacity:1"
+         style="fill:#3c31d4;fill-opacity:1;fill-rule:evenodd;stroke:#3c31d4;stroke-width:1pt;stroke-opacity:1"
          transform="matrix(0.4,0,0,0.4,4,0)"
          inkscape:connector-curvature="0" />
     </marker>
@@ -222,7 +222,7 @@
        style="font-style:normal;font-variant:normal;font-weight:bold;font-stretch:normal;font-size:16.50419998px;line-height:125%;font-family:Roboto;-inkscape-font-specification:'Roboto, Bold';text-align:start;writing-mode:lr-tb;text-anchor:start">Company 2</tspan>
   </text>
   <path
-     style="fill:none;fill-rule:evenodd;stroke:#88c9d3;stroke-width:1.27900004;stroke-linecap:butt;stroke-linejoin:miter;stroke-miterlimit:4;stroke-dasharray:none;stroke-opacity:1"
+     style="fill:none;fill-rule:evenodd;stroke:#3c31d4;stroke-width:1.27900004;stroke-linecap:butt;stroke-linejoin:miter;stroke-miterlimit:4;stroke-dasharray:none;stroke-opacity:1"
      d="m 302.6304,221.82003 0,-67.86027 -19.8444,0"
      id="path12354"
      inkscape:connector-curvature="0"
@@ -240,7 +240,7 @@
   <path
      class="cls-11"
      id="circle209-7-4"
-     style="fill:none;stroke:#88c9d3;stroke-width:5.2750001;stroke-linecap:round;stroke-miterlimit:10;stroke-dasharray:none;stroke-opacity:1"
+     style="fill:none;stroke:#3c31d4;stroke-width:5.2750001;stroke-linecap:round;stroke-miterlimit:10;stroke-dasharray:none;stroke-opacity:1"
      inkscape:transform-center-x="10.662373"
      inkscape:transform-center-y="141.07188"
      sodipodi:type="arc"
@@ -256,7 +256,7 @@
   <ellipse
      class="cls-11"
      id="circle209-7-4-3-8"
-     style="fill:none;stroke:#88c9d3;stroke-width:1.55800009;stroke-linecap:round;stroke-miterlimit:10;stroke-dasharray:none;stroke-opacity:1"
+     style="fill:none;stroke:#3c31d4;stroke-width:1.55800009;stroke-linecap:round;stroke-miterlimit:10;stroke-dasharray:none;stroke-opacity:1"
      inkscape:transform-center-x="-7.4064808"
      inkscape:transform-center-y="101.72231"
      cx="280.80981"
@@ -266,7 +266,7 @@
   <path
      class="cls-11"
      id="circle209-7-4-3"
-     style="fill:none;stroke:#88c9d3;stroke-width:5.2750001;stroke-linecap:round;stroke-miterlimit:10;stroke-dasharray:none;stroke-opacity:1"
+     style="fill:none;stroke:#3c31d4;stroke-width:5.2750001;stroke-linecap:round;stroke-miterlimit:10;stroke-dasharray:none;stroke-opacity:1"
      inkscape:transform-center-x="-7.4064809"
      inkscape:transform-center-y="101.72231"
      sodipodi:type="arc"
@@ -287,7 +287,7 @@
      rx="46.465233"
      ry="46.488892" />
   <path
-     style="fill:none;fill-rule:evenodd;stroke:#88c9d3;stroke-width:1.27900004;stroke-linecap:butt;stroke-linejoin:round;stroke-miterlimit:4;stroke-dasharray:none;stroke-opacity:1;marker-end:url(#Arrow1Mend)"
+     style="fill:none;fill-rule:evenodd;stroke:#3c31d4;stroke-width:1.27900004;stroke-linecap:butt;stroke-linejoin:round;stroke-miterlimit:4;stroke-dasharray:none;stroke-opacity:1;marker-end:url(#Arrow1Mend)"
      d="m 262.9667,234.04488 -1.27613,0 0,-80.08546 21.09543,3.4e-4 4.7e-4,-29.31552"
      id="path12354-8"
      inkscape:connector-curvature="0"

--- a/docs/_assets/Diag5-sourcesData.svg
+++ b/docs/_assets/Diag5-sourcesData.svg
@@ -110,7 +110,7 @@
        orient="auto">
       <path
          transform="matrix(-0.8,0,0,-0.8,-10,0)"
-         style="fill:#00deb6;fill-opacity:1;fill-rule:evenodd;stroke:#00deb6;stroke-width:1pt;stroke-opacity:1"
+         style="fill:#3c31d4;fill-opacity:1;fill-rule:evenodd;stroke:#3c31d4;stroke-width:1pt;stroke-opacity:1"
          d="M 0,0 5,-5 -12.5,0 5,5 0,0 Z"
          id="path4371"
          inkscape:connector-curvature="0" />
@@ -123,7 +123,7 @@
        orient="auto">
       <path
          transform="matrix(-0.4,0,0,-0.4,-4,0)"
-         style="fill:#00deb6;fill-opacity:1;fill-rule:evenodd;stroke:#00deb6;stroke-width:1pt;stroke-opacity:1"
+         style="fill:#3c31d4;fill-opacity:1;fill-rule:evenodd;stroke:#3c31d4;stroke-width:1pt;stroke-opacity:1"
          d="M 0,0 5,-5 -12.5,0 5,5 0,0 Z"
          id="path4377"
          inkscape:connector-curvature="0" />
@@ -136,13 +136,13 @@
        orient="auto">
       <path
          transform="matrix(0.4,0,0,0.4,4,0)"
-         style="fill:#88c9d3;fill-opacity:1;fill-rule:evenodd;stroke:#88c9d3;stroke-width:1pt;stroke-opacity:1"
+         style="fill:#3c31d4;fill-opacity:1;fill-rule:evenodd;stroke:#3c31d4;stroke-width:1pt;stroke-opacity:1"
          d="M 0,0 5,-5 -12.5,0 5,5 0,0 Z"
          id="path4374"
          inkscape:connector-curvature="0" />
     </marker>
     <style
-       id="style5">.cls-1,.cls-10,.cls-11,.cls-7,.cls-8{fill:none;}.cls-1,.cls-11{stroke:#00deb6;}.cls-1,.cls-10,.cls-11,.cls-7{stroke-miterlimit:10;}.cls-2{fill:#00deb6;}.cls-3{font-size:16px;fill:#262737;}.cls-12,.cls-3{font-family:HKGrotesk-SemiBold, HK Grotesk;font-weight:700;}.cls-4{letter-spacing:-0.03em;}.cls-5{letter-spacing:-0.02em;}.cls-6{letter-spacing:0em;}.cls-7{stroke:#262737;}.cls-11,.cls-7{stroke-width:5px;}.cls-9{letter-spacing:-0.01em;}.cls-10{stroke:#e6e6e6;}.cls-12{font-size:12px;fill:gray;}.cls-13{letter-spacing:-0.03em;}.cls-14{letter-spacing:-0.01em;}.cls-15{letter-spacing:-0.02em;}.cls-16{letter-spacing:0em;}.cls-17{letter-spacing:0em;}.cls-18{letter-spacing:0em;}</style>
+       id="style5">.cls-1,.cls-10,.cls-11,.cls-7,.cls-8{fill:none;}.cls-1,.cls-11{stroke:#3c31d4;}.cls-1,.cls-10,.cls-11,.cls-7{stroke-miterlimit:10;}.cls-2{fill:#3c31d4;}.cls-3{font-size:16px;fill:#262737;}.cls-12,.cls-3{font-family:HKGrotesk-SemiBold, HK Grotesk;font-weight:700;}.cls-4{letter-spacing:-0.03em;}.cls-5{letter-spacing:-0.02em;}.cls-6{letter-spacing:0em;}.cls-7{stroke:#262737;}.cls-11,.cls-7{stroke-width:5px;}.cls-9{letter-spacing:-0.01em;}.cls-10{stroke:#e6e6e6;}.cls-12{font-size:12px;fill:gray;}.cls-13{letter-spacing:-0.03em;}.cls-14{letter-spacing:-0.01em;}.cls-15{letter-spacing:-0.02em;}.cls-16{letter-spacing:0em;}.cls-17{letter-spacing:0em;}.cls-18{letter-spacing:0em;}</style>
     <marker
        style="overflow:visible"
        id="Arrow1Mstart-2"
@@ -151,7 +151,7 @@
        orient="auto">
       <path
          transform="matrix(0.4,0,0,0.4,4,0)"
-         style="fill:#88c9d3;fill-opacity:1;fill-rule:evenodd;stroke:#88c9d3;stroke-width:1pt;stroke-opacity:1"
+         style="fill:#3c31d4;fill-opacity:1;fill-rule:evenodd;stroke:#3c31d4;stroke-width:1pt;stroke-opacity:1"
          d="M 0,0 5,-5 -12.5,0 5,5 0,0 Z"
          id="path4374-0"
          inkscape:connector-curvature="0" />
@@ -212,7 +212,7 @@
        orient="auto">
       <path
          transform="matrix(0.4,0,0,0.4,4,0)"
-         style="fill:#00deb6;fill-opacity:1;fill-rule:evenodd;stroke:#00deb6;stroke-width:1pt;stroke-opacity:1"
+         style="fill:#3c31d4;fill-opacity:1;fill-rule:evenodd;stroke:#3c31d4;stroke-width:1pt;stroke-opacity:1"
          d="M 0,0 5,-5 -12.5,0 5,5 0,0 Z"
          id="path4374-0-0"
          inkscape:connector-curvature="0" />
@@ -225,7 +225,7 @@
        orient="auto">
       <path
          transform="matrix(0.4,0,0,0.4,4,0)"
-         style="fill:#00deb6;fill-opacity:1;fill-rule:evenodd;stroke:#00deb6;stroke-width:1pt;stroke-opacity:1"
+         style="fill:#3c31d4;fill-opacity:1;fill-rule:evenodd;stroke:#3c31d4;stroke-width:1pt;stroke-opacity:1"
          d="M 0,0 5,-5 -12.5,0 5,5 0,0 Z"
          id="path4374-9"
          inkscape:connector-curvature="0" />
@@ -238,7 +238,7 @@
        orient="auto">
       <path
          transform="matrix(0.4,0,0,0.4,4,0)"
-         style="fill:#88c9d3;fill-opacity:1;fill-rule:evenodd;stroke:#88c9d3;stroke-width:1pt;stroke-opacity:1"
+         style="fill:#3c31d4;fill-opacity:1;fill-rule:evenodd;stroke:#3c31d4;stroke-width:1pt;stroke-opacity:1"
          d="M 0,0 5,-5 -12.5,0 5,5 0,0 Z"
          id="path4374-0-9"
          inkscape:connector-curvature="0" />
@@ -438,15 +438,15 @@
   <path
      id="path12354"
      d="m 306.51376,139.82678 0,45.74281 0,0"
-     style="fill:none;fill-rule:evenodd;stroke:#88c9d3;stroke-width:0.7696836;stroke-linecap:butt;stroke-linejoin:miter;stroke-miterlimit:4;stroke-dasharray:none;stroke-opacity:1;marker-start:url(#Arrow1Mstart)"
+     style="fill:none;fill-rule:evenodd;stroke:#3c31d4;stroke-width:0.7696836;stroke-linecap:butt;stroke-linejoin:miter;stroke-miterlimit:4;stroke-dasharray:none;stroke-opacity:1;marker-start:url(#Arrow1Mstart)"
      inkscape:connector-curvature="0" />
   <path
      id="path12354-2"
      d="m 306.51376,228.7386 0,40.68209 0,0"
-     style="fill:none;fill-rule:evenodd;stroke:#88c9d3;stroke-width:0.72243828;stroke-linecap:butt;stroke-linejoin:miter;stroke-miterlimit:4;stroke-dasharray:none;stroke-opacity:1;marker-start:url(#Arrow1Mstart-2)"
+     style="fill:none;fill-rule:evenodd;stroke:#3c31d4;stroke-width:0.72243828;stroke-linecap:butt;stroke-linejoin:miter;stroke-miterlimit:4;stroke-dasharray:none;stroke-opacity:1;marker-start:url(#Arrow1Mstart-2)"
      inkscape:connector-curvature="0" />
   <circle
-     style="fill:none;stroke:#88c9d3;stroke-width:3.44641423px;stroke-miterlimit:10;stroke-opacity:1"
+     style="fill:none;stroke:#3c31d4;stroke-width:3.44641423px;stroke-miterlimit:10;stroke-opacity:1"
      id="circle209-2"
      r="22.057053"
      cy="293.12616"
@@ -461,7 +461,7 @@
      class="cls-11" />
   <path
      d="m 315.06812,218.84205 a 17.108697,17.108697 0 0 1 -20.0023,-2.10233 17.108697,17.108697 0 0 1 -4.18162,-19.67297 17.108697,17.108697 0 0 1 17.41792,-10.05625"
-     style="fill:none;stroke:#88c9d3;stroke-width:3.44663262;stroke-linecap:round;stroke-miterlimit:10;stroke-dasharray:none;stroke-opacity:1"
+     style="fill:none;stroke:#3c31d4;stroke-width:3.44663262;stroke-linecap:round;stroke-miterlimit:10;stroke-dasharray:none;stroke-opacity:1"
      id="circle209-7-4"
      class="cls-11"
      inkscape:connector-curvature="0" />

--- a/docs/_assets/Diag6-registers.svg
+++ b/docs/_assets/Diag6-registers.svg
@@ -118,7 +118,7 @@
        orient="auto">
       <path
          transform="matrix(-0.8,0,0,-0.8,-10,0)"
-         style="fill:#00deb6;fill-opacity:1;fill-rule:evenodd;stroke:#00deb6;stroke-width:1pt;stroke-opacity:1"
+         style="fill:#3c31d4;fill-opacity:1;fill-rule:evenodd;stroke:#3c31d4;stroke-width:1pt;stroke-opacity:1"
          d="M 0,0 5,-5 -12.5,0 5,5 0,0 Z"
          id="path4371"
          inkscape:connector-curvature="0" />
@@ -131,7 +131,7 @@
        orient="auto">
       <path
          transform="matrix(-0.4,0,0,-0.4,-4,0)"
-         style="fill:#00deb6;fill-opacity:1;fill-rule:evenodd;stroke:#00deb6;stroke-width:1pt;stroke-opacity:1"
+         style="fill:#3c31d4;fill-opacity:1;fill-rule:evenodd;stroke:#3c31d4;stroke-width:1pt;stroke-opacity:1"
          d="M 0,0 5,-5 -12.5,0 5,5 0,0 Z"
          id="path4377"
          inkscape:connector-curvature="0" />
@@ -144,13 +144,13 @@
        orient="auto">
       <path
          transform="matrix(0.4,0,0,0.4,4,0)"
-         style="fill:#88c9d3;fill-opacity:1;fill-rule:evenodd;stroke:#88c9d3;stroke-width:1pt;stroke-opacity:1"
+         style="fill:#3c31d4;fill-opacity:1;fill-rule:evenodd;stroke:#3c31d4;stroke-width:1pt;stroke-opacity:1"
          d="M 0,0 5,-5 -12.5,0 5,5 0,0 Z"
          id="path4374"
          inkscape:connector-curvature="0" />
     </marker>
     <style
-       id="style5">.cls-1,.cls-10,.cls-11,.cls-7,.cls-8{fill:none;}.cls-1,.cls-11{stroke:#00deb6;}.cls-1,.cls-10,.cls-11,.cls-7{stroke-miterlimit:10;}.cls-2{fill:#00deb6;}.cls-3{font-size:16px;fill:#262737;}.cls-12,.cls-3{font-family:HKGrotesk-SemiBold, HK Grotesk;font-weight:700;}.cls-4{letter-spacing:-0.03em;}.cls-5{letter-spacing:-0.02em;}.cls-6{letter-spacing:0em;}.cls-7{stroke:#262737;}.cls-11,.cls-7{stroke-width:5px;}.cls-9{letter-spacing:-0.01em;}.cls-10{stroke:#e6e6e6;}.cls-12{font-size:12px;fill:gray;}.cls-13{letter-spacing:-0.03em;}.cls-14{letter-spacing:-0.01em;}.cls-15{letter-spacing:-0.02em;}.cls-16{letter-spacing:0em;}.cls-17{letter-spacing:0em;}.cls-18{letter-spacing:0em;}</style>
+       id="style5">.cls-1,.cls-10,.cls-11,.cls-7,.cls-8{fill:none;}.cls-1,.cls-11{stroke:#3c31d4;}.cls-1,.cls-10,.cls-11,.cls-7{stroke-miterlimit:10;}.cls-2{fill:#3c31d4;}.cls-3{font-size:16px;fill:#262737;}.cls-12,.cls-3{font-family:HKGrotesk-SemiBold, HK Grotesk;font-weight:700;}.cls-4{letter-spacing:-0.03em;}.cls-5{letter-spacing:-0.02em;}.cls-6{letter-spacing:0em;}.cls-7{stroke:#262737;}.cls-11,.cls-7{stroke-width:5px;}.cls-9{letter-spacing:-0.01em;}.cls-10{stroke:#e6e6e6;}.cls-12{font-size:12px;fill:gray;}.cls-13{letter-spacing:-0.03em;}.cls-14{letter-spacing:-0.01em;}.cls-15{letter-spacing:-0.02em;}.cls-16{letter-spacing:0em;}.cls-17{letter-spacing:0em;}.cls-18{letter-spacing:0em;}</style>
     <marker
        style="overflow:visible"
        id="Arrow1Mstart-2"
@@ -159,7 +159,7 @@
        orient="auto">
       <path
          transform="matrix(0.4,0,0,0.4,4,0)"
-         style="fill:#88c9d3;fill-opacity:1;fill-rule:evenodd;stroke:#88c9d3;stroke-width:1pt;stroke-opacity:1"
+         style="fill:#3c31d4;fill-opacity:1;fill-rule:evenodd;stroke:#3c31d4;stroke-width:1pt;stroke-opacity:1"
          d="M 0,0 5,-5 -12.5,0 5,5 0,0 Z"
          id="path4374-0"
          inkscape:connector-curvature="0" />
@@ -220,7 +220,7 @@
        orient="auto">
       <path
          transform="matrix(0.4,0,0,0.4,4,0)"
-         style="fill:#00deb6;fill-opacity:1;fill-rule:evenodd;stroke:#00deb6;stroke-width:1pt;stroke-opacity:1"
+         style="fill:#3c31d4;fill-opacity:1;fill-rule:evenodd;stroke:#3c31d4;stroke-width:1pt;stroke-opacity:1"
          d="M 0,0 5,-5 -12.5,0 5,5 0,0 Z"
          id="path4374-0-0"
          inkscape:connector-curvature="0" />
@@ -233,7 +233,7 @@
        orient="auto">
       <path
          transform="matrix(0.4,0,0,0.4,4,0)"
-         style="fill:#00deb6;fill-opacity:1;fill-rule:evenodd;stroke:#00deb6;stroke-width:1pt;stroke-opacity:1"
+         style="fill:#3c31d4;fill-opacity:1;fill-rule:evenodd;stroke:#3c31d4;stroke-width:1pt;stroke-opacity:1"
          d="M 0,0 5,-5 -12.5,0 5,5 0,0 Z"
          id="path4374-9"
          inkscape:connector-curvature="0" />
@@ -246,7 +246,7 @@
        orient="auto">
       <path
          transform="matrix(0.4,0,0,0.4,4,0)"
-         style="fill:#88c9d3;fill-opacity:1;fill-rule:evenodd;stroke:#88c9d3;stroke-width:1pt;stroke-opacity:1"
+         style="fill:#3c31d4;fill-opacity:1;fill-rule:evenodd;stroke:#3c31d4;stroke-width:1pt;stroke-opacity:1"
          d="M 0,0 5,-5 -12.5,0 5,5 0,0 Z"
          id="path4374-0-9"
          inkscape:connector-curvature="0" />

--- a/docs/_assets/Diag7-dataStandardBlackBox.svg
+++ b/docs/_assets/Diag7-dataStandardBlackBox.svg
@@ -127,7 +127,7 @@
        orient="auto">
       <path
          transform="matrix(-0.8,0,0,-0.8,-10,0)"
-         style="fill:#00deb6;fill-opacity:1;fill-rule:evenodd;stroke:#00deb6;stroke-width:1pt;stroke-opacity:1"
+         style="fill:#3c31d4;fill-opacity:1;fill-rule:evenodd;stroke:#3c31d4;stroke-width:1pt;stroke-opacity:1"
          d="M 0,0 5,-5 -12.5,0 5,5 0,0 Z"
          id="path4371"
          inkscape:connector-curvature="0" />
@@ -140,7 +140,7 @@
        orient="auto">
       <path
          transform="matrix(-0.4,0,0,-0.4,-4,0)"
-         style="fill:#00deb6;fill-opacity:1;fill-rule:evenodd;stroke:#00deb6;stroke-width:1pt;stroke-opacity:1"
+         style="fill:#3c31d4;fill-opacity:1;fill-rule:evenodd;stroke:#3c31d4;stroke-width:1pt;stroke-opacity:1"
          d="M 0,0 5,-5 -12.5,0 5,5 0,0 Z"
          id="path4377"
          inkscape:connector-curvature="0" />
@@ -153,13 +153,13 @@
        orient="auto">
       <path
          transform="matrix(0.4,0,0,0.4,4,0)"
-         style="fill:#88c9d3;fill-opacity:1;fill-rule:evenodd;stroke:#88c9d3;stroke-width:1pt;stroke-opacity:1"
+         style="fill:#3c31d4;fill-opacity:1;fill-rule:evenodd;stroke:#3c31d4;stroke-width:1pt;stroke-opacity:1"
          d="M 0,0 5,-5 -12.5,0 5,5 0,0 Z"
          id="path4374"
          inkscape:connector-curvature="0" />
     </marker>
     <style
-       id="style5">.cls-1,.cls-10,.cls-11,.cls-7,.cls-8{fill:none;}.cls-1,.cls-11{stroke:#00deb6;}.cls-1,.cls-10,.cls-11,.cls-7{stroke-miterlimit:10;}.cls-2{fill:#00deb6;}.cls-3{font-size:16px;fill:#262737;}.cls-12,.cls-3{font-family:HKGrotesk-SemiBold, HK Grotesk;font-weight:700;}.cls-4{letter-spacing:-0.03em;}.cls-5{letter-spacing:-0.02em;}.cls-6{letter-spacing:0em;}.cls-7{stroke:#262737;}.cls-11,.cls-7{stroke-width:5px;}.cls-9{letter-spacing:-0.01em;}.cls-10{stroke:#e6e6e6;}.cls-12{font-size:12px;fill:gray;}.cls-13{letter-spacing:-0.03em;}.cls-14{letter-spacing:-0.01em;}.cls-15{letter-spacing:-0.02em;}.cls-16{letter-spacing:0em;}.cls-17{letter-spacing:0em;}.cls-18{letter-spacing:0em;}</style>
+       id="style5">.cls-1,.cls-10,.cls-11,.cls-7,.cls-8{fill:none;}.cls-1,.cls-11{stroke:#3c31d4;}.cls-1,.cls-10,.cls-11,.cls-7{stroke-miterlimit:10;}.cls-2{fill:#3c31d4;}.cls-3{font-size:16px;fill:#262737;}.cls-12,.cls-3{font-family:HKGrotesk-SemiBold, HK Grotesk;font-weight:700;}.cls-4{letter-spacing:-0.03em;}.cls-5{letter-spacing:-0.02em;}.cls-6{letter-spacing:0em;}.cls-7{stroke:#262737;}.cls-11,.cls-7{stroke-width:5px;}.cls-9{letter-spacing:-0.01em;}.cls-10{stroke:#e6e6e6;}.cls-12{font-size:12px;fill:gray;}.cls-13{letter-spacing:-0.03em;}.cls-14{letter-spacing:-0.01em;}.cls-15{letter-spacing:-0.02em;}.cls-16{letter-spacing:0em;}.cls-17{letter-spacing:0em;}.cls-18{letter-spacing:0em;}</style>
     <marker
        style="overflow:visible"
        id="Arrow1Mstart-2"
@@ -168,7 +168,7 @@
        orient="auto">
       <path
          transform="matrix(0.4,0,0,0.4,4,0)"
-         style="fill:#88c9d3;fill-opacity:1;fill-rule:evenodd;stroke:#88c9d3;stroke-width:1pt;stroke-opacity:1"
+         style="fill:#3c31d4;fill-opacity:1;fill-rule:evenodd;stroke:#3c31d4;stroke-width:1pt;stroke-opacity:1"
          d="M 0,0 5,-5 -12.5,0 5,5 0,0 Z"
          id="path4374-0"
          inkscape:connector-curvature="0" />
@@ -229,7 +229,7 @@
        orient="auto">
       <path
          transform="matrix(0.4,0,0,0.4,4,0)"
-         style="fill:#00deb6;fill-opacity:1;fill-rule:evenodd;stroke:#00deb6;stroke-width:1pt;stroke-opacity:1"
+         style="fill:#3c31d4;fill-opacity:1;fill-rule:evenodd;stroke:#3c31d4;stroke-width:1pt;stroke-opacity:1"
          d="M 0,0 5,-5 -12.5,0 5,5 0,0 Z"
          id="path4374-0-0"
          inkscape:connector-curvature="0" />
@@ -242,7 +242,7 @@
        orient="auto">
       <path
          transform="matrix(0.4,0,0,0.4,4,0)"
-         style="fill:#00deb6;fill-opacity:1;fill-rule:evenodd;stroke:#00deb6;stroke-width:1pt;stroke-opacity:1"
+         style="fill:#3c31d4;fill-opacity:1;fill-rule:evenodd;stroke:#3c31d4;stroke-width:1pt;stroke-opacity:1"
          d="M 0,0 5,-5 -12.5,0 5,5 0,0 Z"
          id="path4374-9"
          inkscape:connector-curvature="0" />
@@ -255,7 +255,7 @@
        orient="auto">
       <path
          transform="matrix(0.4,0,0,0.4,4,0)"
-         style="fill:#88c9d3;fill-opacity:1;fill-rule:evenodd;stroke:#88c9d3;stroke-width:1pt;stroke-opacity:1"
+         style="fill:#3c31d4;fill-opacity:1;fill-rule:evenodd;stroke:#3c31d4;stroke-width:1pt;stroke-opacity:1"
          d="M 0,0 5,-5 -12.5,0 5,5 0,0 Z"
          id="path4374-0-9"
          inkscape:connector-curvature="0" />
@@ -332,7 +332,7 @@
          inkscape:connector-curvature="0"
          id="path4374-0-2-8-3"
          d="M 0,0 5,-5 -12.5,0 5,5 0,0 Z"
-         style="fill:#88c9d3;fill-opacity:1;fill-rule:evenodd;stroke:#88c9d3;stroke-width:1pt;stroke-opacity:1"
+         style="fill:#3c31d4;fill-opacity:1;fill-rule:evenodd;stroke:#3c31d4;stroke-width:1pt;stroke-opacity:1"
          transform="matrix(0.4,0,0,0.4,4,0)" />
     </marker>
     <marker
@@ -347,7 +347,7 @@
          inkscape:connector-curvature="0"
          id="path4374-0-2-8"
          d="M 0,0 5,-5 -12.5,0 5,5 0,0 Z"
-         style="fill:#88c9d3;fill-opacity:1;fill-rule:evenodd;stroke:#88c9d3;stroke-width:1pt;stroke-opacity:1"
+         style="fill:#3c31d4;fill-opacity:1;fill-rule:evenodd;stroke:#3c31d4;stroke-width:1pt;stroke-opacity:1"
          transform="matrix(0.4,0,0,0.4,4,0)" />
     </marker>
     <clipPath
@@ -378,7 +378,7 @@
          inkscape:connector-curvature="0"
          id="path4374-0-2"
          d="M 0,0 5,-5 -12.5,0 5,5 0,0 Z"
-         style="fill:#88c9d3;fill-opacity:1;fill-rule:evenodd;stroke:#88c9d3;stroke-width:1pt;stroke-opacity:1"
+         style="fill:#3c31d4;fill-opacity:1;fill-rule:evenodd;stroke:#3c31d4;stroke-width:1pt;stroke-opacity:1"
          transform="matrix(0.4,0,0,0.4,4,0)" />
     </marker>
     <marker
@@ -393,7 +393,7 @@
          inkscape:connector-curvature="0"
          id="path4374-0-6"
          d="M 0,0 5,-5 -12.5,0 5,5 0,0 Z"
-         style="fill:#88c9d3;fill-opacity:1;fill-rule:evenodd;stroke:#88c9d3;stroke-width:1pt;stroke-opacity:1"
+         style="fill:#3c31d4;fill-opacity:1;fill-rule:evenodd;stroke:#3c31d4;stroke-width:1pt;stroke-opacity:1"
          transform="matrix(0.4,0,0,0.4,4,0)" />
     </marker>
     <marker
@@ -407,7 +407,7 @@
       <path
          id="path4374-4"
          d="M 0,0 5,-5 -12.5,0 5,5 0,0 Z"
-         style="fill:#88c9d3;fill-opacity:1;fill-rule:evenodd;stroke:#88c9d3;stroke-width:1pt;stroke-opacity:1"
+         style="fill:#3c31d4;fill-opacity:1;fill-rule:evenodd;stroke:#3c31d4;stroke-width:1pt;stroke-opacity:1"
          transform="matrix(0.4,0,0,0.4,4,0)"
          inkscape:connector-curvature="0" />
     </marker>
@@ -447,7 +447,7 @@
          inkscape:connector-curvature="0"
          id="path4374-0-23"
          d="M 0,0 5,-5 -12.5,0 5,5 0,0 Z"
-         style="fill:#88c9d3;fill-opacity:1;fill-rule:evenodd;stroke:#88c9d3;stroke-width:1pt;stroke-opacity:1"
+         style="fill:#3c31d4;fill-opacity:1;fill-rule:evenodd;stroke:#3c31d4;stroke-width:1pt;stroke-opacity:1"
          transform="matrix(0.4,0,0,0.4,4,0)" />
     </marker>
     <marker
@@ -461,7 +461,7 @@
       <path
          id="path4374-06"
          d="M 0,0 5,-5 -12.5,0 5,5 0,0 Z"
-         style="fill:#88c9d3;fill-opacity:1;fill-rule:evenodd;stroke:#88c9d3;stroke-width:1pt;stroke-opacity:1"
+         style="fill:#3c31d4;fill-opacity:1;fill-rule:evenodd;stroke:#3c31d4;stroke-width:1pt;stroke-opacity:1"
          transform="matrix(0.4,0,0,0.4,4,0)"
          inkscape:connector-curvature="0" />
     </marker>
@@ -1256,7 +1256,7 @@
      style="filter:url(#filter9537)"
      transform="matrix(2.2,0,0,2.2,-23.40734,-39.28993)">
     <path
-       style="fill:#00deb6"
+       style="fill:#3c31d4"
        inkscape:connector-curvature="0"
        id="path11"
        d="M 157.71188,143.14176 Z"
@@ -1410,43 +1410,43 @@
        d="m 157.71188,143.14176 0,0"
        class="cls-10" />
     <path
-       style="fill:none;stroke:#00deb6;stroke-width:1.47422945px;stroke-miterlimit:10"
+       style="fill:none;stroke:#3c31d4;stroke-width:1.47422945px;stroke-miterlimit:10"
        inkscape:connector-curvature="0"
        id="path79"
        d="m 157.71188,143.14176 0,0"
        class="cls-11" />
     <path
-       style="fill:none;stroke:#00deb6;stroke-width:1.47422945px;stroke-miterlimit:10"
+       style="fill:none;stroke:#3c31d4;stroke-width:1.47422945px;stroke-miterlimit:10"
        inkscape:connector-curvature="0"
        id="path85"
        d="m 157.71188,143.14176 0,0"
        class="cls-11" />
     <path
-       style="fill:none;stroke:#00deb6;stroke-width:1.47422945px;stroke-miterlimit:10"
+       style="fill:none;stroke:#3c31d4;stroke-width:1.47422945px;stroke-miterlimit:10"
        inkscape:connector-curvature="0"
        id="path87"
        d="m 157.71188,143.14176 0,0"
        class="cls-11" />
     <path
-       style="fill:none;stroke:#00deb6;stroke-width:1.47422945px;stroke-miterlimit:10"
+       style="fill:none;stroke:#3c31d4;stroke-width:1.47422945px;stroke-miterlimit:10"
        inkscape:connector-curvature="0"
        id="path89"
        d="m 157.71188,143.14176 0,0"
        class="cls-11" />
     <path
-       style="fill:none;stroke:#00deb6;stroke-width:1.47422945px;stroke-miterlimit:10"
+       style="fill:none;stroke:#3c31d4;stroke-width:1.47422945px;stroke-miterlimit:10"
        inkscape:connector-curvature="0"
        id="path91"
        d="m 157.71188,143.14176 0,0"
        class="cls-11" />
     <path
-       style="fill:none;stroke:#00deb6;stroke-width:1.47422945px;stroke-miterlimit:10"
+       style="fill:none;stroke:#3c31d4;stroke-width:1.47422945px;stroke-miterlimit:10"
        inkscape:connector-curvature="0"
        id="path93"
        d="m 157.71188,143.14176 0,0"
        class="cls-11" />
     <path
-       style="fill:none;stroke:#00deb6;stroke-width:1.47422945px;stroke-miterlimit:10"
+       style="fill:none;stroke:#3c31d4;stroke-width:1.47422945px;stroke-miterlimit:10"
        inkscape:connector-curvature="0"
        id="path95"
        d="m 157.71188,143.14176 0,0"
@@ -1524,13 +1524,13 @@
        d="m 157.71188,143.14176 0,0"
        class="cls-10" />
     <path
-       style="fill:#00deb6"
+       style="fill:#3c31d4"
        inkscape:connector-curvature="0"
        id="path171"
        d="M 157.71188,143.14176 Z"
        class="cls-2" />
     <path
-       style="fill:#00deb6"
+       style="fill:#3c31d4"
        inkscape:connector-curvature="0"
        id="path197"
        d="M 157.71188,143.14176 Z"
@@ -1562,12 +1562,12 @@
        inkscape:connector-curvature="0"
        id="path12354"
        d="m 183.91639,167.352 0,26.82828 0,0"
-       style="fill:none;fill-rule:evenodd;stroke:#88c9d3;stroke-width:0.41251066;stroke-linecap:butt;stroke-linejoin:miter;stroke-miterlimit:4;stroke-dasharray:none;stroke-opacity:1;marker-start:url(#Arrow1Mstart-26)" />
+       style="fill:none;fill-rule:evenodd;stroke:#3c31d4;stroke-width:0.41251066;stroke-linecap:butt;stroke-linejoin:miter;stroke-miterlimit:4;stroke-dasharray:none;stroke-opacity:1;marker-start:url(#Arrow1Mstart-26)" />
     <path
        inkscape:connector-curvature="0"
        id="path12354-2"
        d="m 183.91639,212.54971 0,22.04674 0,0"
-       style="fill:none;fill-rule:evenodd;stroke:#88c9d3;stroke-width:0.3721852;stroke-linecap:butt;stroke-linejoin:miter;stroke-miterlimit:4;stroke-dasharray:none;stroke-opacity:1;marker-start:url(#Arrow1Mstart-2-0)" />
+       style="fill:none;fill-rule:evenodd;stroke:#3c31d4;stroke-width:0.3721852;stroke-linecap:butt;stroke-linejoin:miter;stroke-miterlimit:4;stroke-dasharray:none;stroke-opacity:1;marker-start:url(#Arrow1Mstart-2-0)" />
     <path
        sodipodi:open="true"
        d="m 189.39029,245.17457 a 11.371257,11.371257 0 0 1 -8.89022,10.99646 11.371257,11.371257 0 0 1 -12.7262,-6.16456 11.371257,11.371257 0 0 1 3.11763,-13.7927"
@@ -1580,7 +1580,7 @@
        sodipodi:type="arc"
        inkscape:transform-center-y="37.642707"
        inkscape:transform-center-x="-2.7421856"
-       style="fill:none;stroke:#88c9d3;stroke-width:1.77687132;stroke-linecap:round;stroke-miterlimit:10;stroke-dasharray:none;stroke-opacity:1"
+       style="fill:none;stroke:#3c31d4;stroke-width:1.77687132;stroke-linecap:round;stroke-miterlimit:10;stroke-dasharray:none;stroke-opacity:1"
        id="circle209-2"
        class="cls-11" />
     <circle
@@ -1604,7 +1604,7 @@
        sodipodi:type="arc"
        inkscape:transform-center-y="27.73734"
        inkscape:transform-center-x="-2.0206011"
-       style="fill:none;stroke:#88c9d3;stroke-width:1.68799269;stroke-linecap:round;stroke-miterlimit:10;stroke-dasharray:none;stroke-opacity:1"
+       style="fill:none;stroke:#3c31d4;stroke-width:1.68799269;stroke-linecap:round;stroke-miterlimit:10;stroke-dasharray:none;stroke-opacity:1"
        id="circle209-7-4"
        class="cls-11" />
     <g
@@ -1722,14 +1722,14 @@
        sodipodi:type="arc"
        inkscape:transform-center-y="35.759808"
        inkscape:transform-center-x="-2.6050228"
-       style="fill:none;stroke:#88c9d3;stroke-width:1.68788588px;stroke-linecap:round;stroke-miterlimit:10;stroke-opacity:1"
+       style="fill:none;stroke:#3c31d4;stroke-width:1.68788588px;stroke-linecap:round;stroke-miterlimit:10;stroke-opacity:1"
        id="circle209-2-0-6"
        class="cls-11" />
     <path
        inkscape:connector-curvature="0"
        id="path12354-3"
        d="m 172.71225,167.72313 0,22.4026 0,0"
-       style="fill:none;fill-rule:evenodd;stroke:#88c9d3;stroke-width:0.37695351;stroke-linecap:butt;stroke-linejoin:miter;stroke-miterlimit:4;stroke-dasharray:none;stroke-opacity:1;marker-start:url(#Arrow1Mstart-9)" />
+       style="fill:none;fill-rule:evenodd;stroke:#3c31d4;stroke-width:0.37695351;stroke-linecap:butt;stroke-linejoin:miter;stroke-miterlimit:4;stroke-dasharray:none;stroke-opacity:1;marker-start:url(#Arrow1Mstart-9)" />
     <path
        sodipodi:open="true"
        d="m 175.24014,189.53637 a 11.416736,11.416736 0 0 1 13.49399,7.13142 11.416736,11.416736 0 0 1 -5.65505,14.17622 11.416736,11.416736 0 0 1 -14.69748,-4.11449 11.416736,11.416736 0 0 1 2.52719,-15.05185"
@@ -1740,7 +1740,7 @@
        sodipodi:cy="200.60963"
        sodipodi:cx="178.01949"
        sodipodi:type="arc"
-       style="fill:none;stroke:#88c9d3;stroke-width:1.68799269;stroke-linecap:round;stroke-miterlimit:10;stroke-dasharray:none;stroke-opacity:1"
+       style="fill:none;stroke:#3c31d4;stroke-width:1.68799269;stroke-linecap:round;stroke-miterlimit:10;stroke-dasharray:none;stroke-opacity:1"
        id="ellipse25-6-0-0"
        class="cls-7" />
     <path
@@ -1755,19 +1755,19 @@
        sodipodi:type="arc"
        inkscape:transform-center-y="37.642706"
        inkscape:transform-center-x="-2.7421856"
-       style="fill:none;stroke:#88c9d3;stroke-width:1.77687132;stroke-linecap:round;stroke-miterlimit:10;stroke-dasharray:none;stroke-opacity:1"
+       style="fill:none;stroke:#3c31d4;stroke-width:1.77687132;stroke-linecap:round;stroke-miterlimit:10;stroke-dasharray:none;stroke-opacity:1"
        id="circle209-2-5"
        class="cls-11" />
     <path
        inkscape:connector-curvature="0"
        id="path12354-2-1"
        d="m 172.71225,233.3226 0,-22.04674 0,0"
-       style="fill:none;fill-rule:evenodd;stroke:#88c9d3;stroke-width:0.3721852;stroke-linecap:butt;stroke-linejoin:miter;stroke-miterlimit:4;stroke-dasharray:none;stroke-opacity:1;marker-start:url(#Arrow1Mstart-2-7)" />
+       style="fill:none;fill-rule:evenodd;stroke:#3c31d4;stroke-width:0.3721852;stroke-linecap:butt;stroke-linejoin:miter;stroke-miterlimit:4;stroke-dasharray:none;stroke-opacity:1;marker-start:url(#Arrow1Mstart-2-7)" />
     <path
        inkscape:connector-curvature="0"
        id="path12354-2-9"
        d="m 127.89641,213.92015 0,18.73674 0,0"
-       style="fill:none;fill-rule:evenodd;stroke:#88c9d3;stroke-width:0.34311071;stroke-linecap:butt;stroke-linejoin:miter;stroke-miterlimit:4;stroke-dasharray:none;stroke-opacity:1;marker-start:url(#Arrow1Mstart-2-90)" />
+       style="fill:none;fill-rule:evenodd;stroke:#3c31d4;stroke-width:0.34311071;stroke-linecap:butt;stroke-linejoin:miter;stroke-miterlimit:4;stroke-dasharray:none;stroke-opacity:1;marker-start:url(#Arrow1Mstart-2-90)" />
     <circle
        r="11.371257"
        cy="245.07364"
@@ -1775,7 +1775,7 @@
        transform="scale(-1,1)"
        inkscape:transform-center-y="37.642701"
        inkscape:transform-center-x="2.7421778"
-       style="fill:none;stroke:#88c9d3;stroke-width:1.77687132;stroke-linecap:round;stroke-miterlimit:10;stroke-dasharray:none;stroke-opacity:1"
+       style="fill:none;stroke:#3c31d4;stroke-width:1.77687132;stroke-linecap:round;stroke-miterlimit:10;stroke-dasharray:none;stroke-opacity:1"
        id="circle209-2-1"
        class="cls-11" />
     <g
@@ -1833,7 +1833,7 @@
        r="11.416736"
        cy="200.60963"
        cx="127.89568"
-       style="fill:none;stroke:#88c9d3;stroke-width:1.68799269;stroke-linecap:round;stroke-miterlimit:10;stroke-dasharray:none;stroke-opacity:1"
+       style="fill:none;stroke:#3c31d4;stroke-width:1.68799269;stroke-linecap:round;stroke-miterlimit:10;stroke-dasharray:none;stroke-opacity:1"
        id="ellipse25-6-0-0-2"
        class="cls-7" />
     <text
@@ -1857,12 +1857,12 @@
        inkscape:connector-curvature="0"
        id="path12354-2-9-4"
        d="m 141.51208,246.32562 24.39057,0 0,0"
-       style="fill:none;fill-rule:evenodd;stroke:#88c9d3;stroke-width:0.3914693;stroke-linecap:butt;stroke-linejoin:miter;stroke-miterlimit:4;stroke-dasharray:none;stroke-opacity:1;marker-start:url(#Arrow1Mstart-2-90-3)" />
+       style="fill:none;fill-rule:evenodd;stroke:#3c31d4;stroke-width:0.3914693;stroke-linecap:butt;stroke-linejoin:miter;stroke-miterlimit:4;stroke-dasharray:none;stroke-opacity:1;marker-start:url(#Arrow1Mstart-2-90-3)" />
     <path
        inkscape:connector-curvature="0"
        id="path12354-2-9-4-7"
        d="m 163.93266,200.60966 -24.39057,0 0,0"
-       style="fill:none;fill-rule:evenodd;stroke:#88c9d3;stroke-width:0.3914693;stroke-linecap:butt;stroke-linejoin:miter;stroke-miterlimit:4;stroke-dasharray:none;stroke-opacity:1;marker-start:url(#Arrow1Mstart-2-90-3-9)" />
+       style="fill:none;fill-rule:evenodd;stroke:#3c31d4;stroke-width:0.3914693;stroke-linecap:butt;stroke-linejoin:miter;stroke-miterlimit:4;stroke-dasharray:none;stroke-opacity:1;marker-start:url(#Arrow1Mstart-2-90-3-9)" />
     <text
        y="201.32022"
        x="83.927193"

--- a/docs/_assets/Diag8-dataStandardTemplate.svg
+++ b/docs/_assets/Diag8-dataStandardTemplate.svg
@@ -127,7 +127,7 @@
        orient="auto">
       <path
          transform="matrix(-0.8,0,0,-0.8,-10,0)"
-         style="fill:#00deb6;fill-opacity:1;fill-rule:evenodd;stroke:#00deb6;stroke-width:1pt;stroke-opacity:1"
+         style="fill:#3c31d4;fill-opacity:1;fill-rule:evenodd;stroke:#3c31d4;stroke-width:1pt;stroke-opacity:1"
          d="M 0,0 5,-5 -12.5,0 5,5 0,0 Z"
          id="path4371"
          inkscape:connector-curvature="0" />
@@ -140,7 +140,7 @@
        orient="auto">
       <path
          transform="matrix(-0.4,0,0,-0.4,-4,0)"
-         style="fill:#00deb6;fill-opacity:1;fill-rule:evenodd;stroke:#00deb6;stroke-width:1pt;stroke-opacity:1"
+         style="fill:#3c31d4;fill-opacity:1;fill-rule:evenodd;stroke:#3c31d4;stroke-width:1pt;stroke-opacity:1"
          d="M 0,0 5,-5 -12.5,0 5,5 0,0 Z"
          id="path4377"
          inkscape:connector-curvature="0" />
@@ -153,13 +153,13 @@
        orient="auto">
       <path
          transform="matrix(0.4,0,0,0.4,4,0)"
-         style="fill:#88c9d3;fill-opacity:1;fill-rule:evenodd;stroke:#88c9d3;stroke-width:1pt;stroke-opacity:1"
+         style="fill:#3c31d4;fill-opacity:1;fill-rule:evenodd;stroke:#3c31d4;stroke-width:1pt;stroke-opacity:1"
          d="M 0,0 5,-5 -12.5,0 5,5 0,0 Z"
          id="path4374"
          inkscape:connector-curvature="0" />
     </marker>
     <style
-       id="style5">.cls-1,.cls-10,.cls-11,.cls-7,.cls-8{fill:none;}.cls-1,.cls-11{stroke:#00deb6;}.cls-1,.cls-10,.cls-11,.cls-7{stroke-miterlimit:10;}.cls-2{fill:#00deb6;}.cls-3{font-size:16px;fill:#262737;}.cls-12,.cls-3{font-family:HKGrotesk-SemiBold, HK Grotesk;font-weight:700;}.cls-4{letter-spacing:-0.03em;}.cls-5{letter-spacing:-0.02em;}.cls-6{letter-spacing:0em;}.cls-7{stroke:#262737;}.cls-11,.cls-7{stroke-width:5px;}.cls-9{letter-spacing:-0.01em;}.cls-10{stroke:#e6e6e6;}.cls-12{font-size:12px;fill:gray;}.cls-13{letter-spacing:-0.03em;}.cls-14{letter-spacing:-0.01em;}.cls-15{letter-spacing:-0.02em;}.cls-16{letter-spacing:0em;}.cls-17{letter-spacing:0em;}.cls-18{letter-spacing:0em;}</style>
+       id="style5">.cls-1,.cls-10,.cls-11,.cls-7,.cls-8{fill:none;}.cls-1,.cls-11{stroke:#3c31d4;}.cls-1,.cls-10,.cls-11,.cls-7{stroke-miterlimit:10;}.cls-2{fill:#3c31d4;}.cls-3{font-size:16px;fill:#262737;}.cls-12,.cls-3{font-family:HKGrotesk-SemiBold, HK Grotesk;font-weight:700;}.cls-4{letter-spacing:-0.03em;}.cls-5{letter-spacing:-0.02em;}.cls-6{letter-spacing:0em;}.cls-7{stroke:#262737;}.cls-11,.cls-7{stroke-width:5px;}.cls-9{letter-spacing:-0.01em;}.cls-10{stroke:#e6e6e6;}.cls-12{font-size:12px;fill:gray;}.cls-13{letter-spacing:-0.03em;}.cls-14{letter-spacing:-0.01em;}.cls-15{letter-spacing:-0.02em;}.cls-16{letter-spacing:0em;}.cls-17{letter-spacing:0em;}.cls-18{letter-spacing:0em;}</style>
     <marker
        style="overflow:visible"
        id="Arrow1Mstart-2"
@@ -168,7 +168,7 @@
        orient="auto">
       <path
          transform="matrix(0.4,0,0,0.4,4,0)"
-         style="fill:#88c9d3;fill-opacity:1;fill-rule:evenodd;stroke:#88c9d3;stroke-width:1pt;stroke-opacity:1"
+         style="fill:#3c31d4;fill-opacity:1;fill-rule:evenodd;stroke:#3c31d4;stroke-width:1pt;stroke-opacity:1"
          d="M 0,0 5,-5 -12.5,0 5,5 0,0 Z"
          id="path4374-0"
          inkscape:connector-curvature="0" />
@@ -229,7 +229,7 @@
        orient="auto">
       <path
          transform="matrix(0.4,0,0,0.4,4,0)"
-         style="fill:#00deb6;fill-opacity:1;fill-rule:evenodd;stroke:#00deb6;stroke-width:1pt;stroke-opacity:1"
+         style="fill:#3c31d4;fill-opacity:1;fill-rule:evenodd;stroke:#3c31d4;stroke-width:1pt;stroke-opacity:1"
          d="M 0,0 5,-5 -12.5,0 5,5 0,0 Z"
          id="path4374-0-0"
          inkscape:connector-curvature="0" />
@@ -242,7 +242,7 @@
        orient="auto">
       <path
          transform="matrix(0.4,0,0,0.4,4,0)"
-         style="fill:#00deb6;fill-opacity:1;fill-rule:evenodd;stroke:#00deb6;stroke-width:1pt;stroke-opacity:1"
+         style="fill:#3c31d4;fill-opacity:1;fill-rule:evenodd;stroke:#3c31d4;stroke-width:1pt;stroke-opacity:1"
          d="M 0,0 5,-5 -12.5,0 5,5 0,0 Z"
          id="path4374-9"
          inkscape:connector-curvature="0" />
@@ -255,7 +255,7 @@
        orient="auto">
       <path
          transform="matrix(0.4,0,0,0.4,4,0)"
-         style="fill:#88c9d3;fill-opacity:1;fill-rule:evenodd;stroke:#88c9d3;stroke-width:1pt;stroke-opacity:1"
+         style="fill:#3c31d4;fill-opacity:1;fill-rule:evenodd;stroke:#3c31d4;stroke-width:1pt;stroke-opacity:1"
          d="M 0,0 5,-5 -12.5,0 5,5 0,0 Z"
          id="path4374-0-9"
          inkscape:connector-curvature="0" />
@@ -332,7 +332,7 @@
          inkscape:connector-curvature="0"
          id="path4374-0-2-8-3"
          d="M 0,0 5,-5 -12.5,0 5,5 0,0 Z"
-         style="fill:#88c9d3;fill-opacity:1;fill-rule:evenodd;stroke:#88c9d3;stroke-width:1pt;stroke-opacity:1"
+         style="fill:#3c31d4;fill-opacity:1;fill-rule:evenodd;stroke:#3c31d4;stroke-width:1pt;stroke-opacity:1"
          transform="matrix(0.4,0,0,0.4,4,0)" />
     </marker>
     <marker
@@ -347,7 +347,7 @@
          inkscape:connector-curvature="0"
          id="path4374-0-2-8"
          d="M 0,0 5,-5 -12.5,0 5,5 0,0 Z"
-         style="fill:#88c9d3;fill-opacity:1;fill-rule:evenodd;stroke:#88c9d3;stroke-width:1pt;stroke-opacity:1"
+         style="fill:#3c31d4;fill-opacity:1;fill-rule:evenodd;stroke:#3c31d4;stroke-width:1pt;stroke-opacity:1"
          transform="matrix(0.4,0,0,0.4,4,0)" />
     </marker>
     <clipPath
@@ -378,7 +378,7 @@
          inkscape:connector-curvature="0"
          id="path4374-0-2"
          d="M 0,0 5,-5 -12.5,0 5,5 0,0 Z"
-         style="fill:#88c9d3;fill-opacity:1;fill-rule:evenodd;stroke:#88c9d3;stroke-width:1pt;stroke-opacity:1"
+         style="fill:#3c31d4;fill-opacity:1;fill-rule:evenodd;stroke:#3c31d4;stroke-width:1pt;stroke-opacity:1"
          transform="matrix(0.4,0,0,0.4,4,0)" />
     </marker>
     <marker
@@ -393,7 +393,7 @@
          inkscape:connector-curvature="0"
          id="path4374-0-6"
          d="M 0,0 5,-5 -12.5,0 5,5 0,0 Z"
-         style="fill:#88c9d3;fill-opacity:1;fill-rule:evenodd;stroke:#88c9d3;stroke-width:1pt;stroke-opacity:1"
+         style="fill:#3c31d4;fill-opacity:1;fill-rule:evenodd;stroke:#3c31d4;stroke-width:1pt;stroke-opacity:1"
          transform="matrix(0.4,0,0,0.4,4,0)" />
     </marker>
     <marker
@@ -407,7 +407,7 @@
       <path
          id="path4374-4"
          d="M 0,0 5,-5 -12.5,0 5,5 0,0 Z"
-         style="fill:#88c9d3;fill-opacity:1;fill-rule:evenodd;stroke:#88c9d3;stroke-width:1pt;stroke-opacity:1"
+         style="fill:#3c31d4;fill-opacity:1;fill-rule:evenodd;stroke:#3c31d4;stroke-width:1pt;stroke-opacity:1"
          transform="matrix(0.4,0,0,0.4,4,0)"
          inkscape:connector-curvature="0" />
     </marker>
@@ -447,7 +447,7 @@
          inkscape:connector-curvature="0"
          id="path4374-0-23"
          d="M 0,0 5,-5 -12.5,0 5,5 0,0 Z"
-         style="fill:#88c9d3;fill-opacity:1;fill-rule:evenodd;stroke:#88c9d3;stroke-width:1pt;stroke-opacity:1"
+         style="fill:#3c31d4;fill-opacity:1;fill-rule:evenodd;stroke:#3c31d4;stroke-width:1pt;stroke-opacity:1"
          transform="matrix(0.4,0,0,0.4,4,0)" />
     </marker>
     <marker
@@ -461,7 +461,7 @@
       <path
          id="path4374-06"
          d="M 0,0 5,-5 -12.5,0 5,5 0,0 Z"
-         style="fill:#88c9d3;fill-opacity:1;fill-rule:evenodd;stroke:#88c9d3;stroke-width:1pt;stroke-opacity:1"
+         style="fill:#3c31d4;fill-opacity:1;fill-rule:evenodd;stroke:#3c31d4;stroke-width:1pt;stroke-opacity:1"
          transform="matrix(0.4,0,0,0.4,4,0)"
          inkscape:connector-curvature="0" />
     </marker>
@@ -1292,7 +1292,7 @@
      d="M 308.41191,346.40904 Z"
      id="path11"
      inkscape:connector-curvature="0"
-     style="fill:#00deb6" />
+     style="fill:#3c31d4" />
   <text
      class="cls-3"
      id="text13"
@@ -1446,43 +1446,43 @@
      d="m 308.41191,346.40904 0,0"
      id="path79"
      inkscape:connector-curvature="0"
-     style="fill:none;stroke:#00deb6;stroke-width:3.21382022px;stroke-miterlimit:10" />
+     style="fill:none;stroke:#3c31d4;stroke-width:3.21382022px;stroke-miterlimit:10" />
   <path
      class="cls-11"
      d="m 308.41191,346.40904 0,0"
      id="path85"
      inkscape:connector-curvature="0"
-     style="fill:none;stroke:#00deb6;stroke-width:3.21382022px;stroke-miterlimit:10" />
+     style="fill:none;stroke:#3c31d4;stroke-width:3.21382022px;stroke-miterlimit:10" />
   <path
      class="cls-11"
      d="m 308.41191,346.40904 0,0"
      id="path87"
      inkscape:connector-curvature="0"
-     style="fill:none;stroke:#00deb6;stroke-width:3.21382022px;stroke-miterlimit:10" />
+     style="fill:none;stroke:#3c31d4;stroke-width:3.21382022px;stroke-miterlimit:10" />
   <path
      class="cls-11"
      d="m 308.41191,346.40904 0,0"
      id="path89"
      inkscape:connector-curvature="0"
-     style="fill:none;stroke:#00deb6;stroke-width:3.21382022px;stroke-miterlimit:10" />
+     style="fill:none;stroke:#3c31d4;stroke-width:3.21382022px;stroke-miterlimit:10" />
   <path
      class="cls-11"
      d="m 308.41191,346.40904 0,0"
      id="path91"
      inkscape:connector-curvature="0"
-     style="fill:none;stroke:#00deb6;stroke-width:3.21382022px;stroke-miterlimit:10" />
+     style="fill:none;stroke:#3c31d4;stroke-width:3.21382022px;stroke-miterlimit:10" />
   <path
      class="cls-11"
      d="m 308.41191,346.40904 0,0"
      id="path93"
      inkscape:connector-curvature="0"
-     style="fill:none;stroke:#00deb6;stroke-width:3.21382022px;stroke-miterlimit:10" />
+     style="fill:none;stroke:#3c31d4;stroke-width:3.21382022px;stroke-miterlimit:10" />
   <path
      class="cls-11"
      d="m 308.41191,346.40904 0,0"
      id="path95"
      inkscape:connector-curvature="0"
-     style="fill:none;stroke:#00deb6;stroke-width:3.21382022px;stroke-miterlimit:10" />
+     style="fill:none;stroke:#3c31d4;stroke-width:3.21382022px;stroke-miterlimit:10" />
   <path
      class="cls-10"
      d="m 308.41191,346.40904 0,0"
@@ -1560,13 +1560,13 @@
      d="M 308.41191,346.40904 Z"
      id="path171"
      inkscape:connector-curvature="0"
-     style="fill:#00deb6" />
+     style="fill:#3c31d4" />
   <path
      class="cls-2"
      d="M 308.41191,346.40904 Z"
      id="path197"
      inkscape:connector-curvature="0"
-     style="fill:#00deb6" />
+     style="fill:#3c31d4" />
   <text
      class="cls-3"
      id="text199"
@@ -1591,19 +1591,19 @@
      id="path213"
      inkscape:connector-curvature="0" />
   <path
-     style="fill:none;fill-rule:evenodd;stroke:#88c9d3;stroke-width:0.89927322;stroke-linecap:butt;stroke-linejoin:miter;stroke-miterlimit:4;stroke-dasharray:none;stroke-opacity:1;marker-start:url(#Arrow1Mstart-26)"
+     style="fill:none;fill-rule:evenodd;stroke:#3c31d4;stroke-width:0.89927322;stroke-linecap:butt;stroke-linejoin:miter;stroke-miterlimit:4;stroke-dasharray:none;stroke-opacity:1;marker-start:url(#Arrow1Mstart-26)"
      d="m 365.53774,399.18736 0,58.48565 0,0"
      id="path12354"
      inkscape:connector-curvature="0" />
   <path
-     style="fill:none;fill-rule:evenodd;stroke:#88c9d3;stroke-width:0.81136376;stroke-linecap:butt;stroke-linejoin:miter;stroke-miterlimit:4;stroke-dasharray:none;stroke-opacity:1;marker-start:url(#Arrow1Mstart-2-0)"
+     style="fill:none;fill-rule:evenodd;stroke:#3c31d4;stroke-width:0.81136376;stroke-linecap:butt;stroke-linejoin:miter;stroke-miterlimit:4;stroke-dasharray:none;stroke-opacity:1;marker-start:url(#Arrow1Mstart-2-0)"
      d="m 365.53774,497.71837 0,48.06189 0,0"
      id="path12354-2"
      inkscape:connector-curvature="0" />
   <path
      class="cls-11"
      id="circle209-2"
-     style="fill:none;stroke:#88c9d3;stroke-width:3.8735795;stroke-linecap:round;stroke-miterlimit:10;stroke-dasharray:none;stroke-opacity:1"
+     style="fill:none;stroke:#3c31d4;stroke-width:3.8735795;stroke-linecap:round;stroke-miterlimit:10;stroke-dasharray:none;stroke-opacity:1"
      inkscape:transform-center-x="-5.9779586"
      inkscape:transform-center-y="82.06109"
      sodipodi:type="arc"
@@ -1627,7 +1627,7 @@
   <path
      class="cls-11"
      id="circle209-7-4"
-     style="fill:none;stroke:#88c9d3;stroke-width:3.67982411;stroke-linecap:round;stroke-miterlimit:10;stroke-dasharray:none;stroke-opacity:1"
+     style="fill:none;stroke:#3c31d4;stroke-width:3.67982411;stroke-linecap:round;stroke-miterlimit:10;stroke-dasharray:none;stroke-opacity:1"
      inkscape:transform-center-x="-4.4049169"
      inkscape:transform-center-y="60.467402"
      sodipodi:type="arc"
@@ -1690,7 +1690,7 @@
   <path
      class="cls-11"
      id="circle209-2-0-6"
-     style="fill:none;stroke:#88c9d3;stroke-width:3.67959118px;stroke-linecap:round;stroke-miterlimit:10;stroke-opacity:1"
+     style="fill:none;stroke:#3c31d4;stroke-width:3.67959118px;stroke-linecap:round;stroke-miterlimit:10;stroke-opacity:1"
      inkscape:transform-center-x="-5.6789437"
      inkscape:transform-center-y="77.956386"
      sodipodi:type="arc"
@@ -1703,14 +1703,14 @@
      d="m 340.9078,450.00911 a 23.549385,23.549385 0 0 1 1.30381,-0.6991"
      sodipodi:open="true" />
   <path
-     style="fill:none;fill-rule:evenodd;stroke:#88c9d3;stroke-width:0.82175863;stroke-linecap:butt;stroke-linejoin:miter;stroke-miterlimit:4;stroke-dasharray:none;stroke-opacity:1;marker-start:url(#Arrow1Mstart-9)"
+     style="fill:none;fill-rule:evenodd;stroke:#3c31d4;stroke-width:0.82175863;stroke-linecap:butt;stroke-linejoin:miter;stroke-miterlimit:4;stroke-dasharray:none;stroke-opacity:1;marker-start:url(#Arrow1Mstart-9)"
      d="m 341.11271,399.99642 0,48.83767 0,0"
      id="path12354-3"
      inkscape:connector-curvature="0" />
   <path
      class="cls-7"
      id="ellipse25-6-0-0"
-     style="fill:none;stroke:#88c9d3;stroke-width:3.67982411;stroke-linecap:round;stroke-miterlimit:10;stroke-dasharray:none;stroke-opacity:1"
+     style="fill:none;stroke:#3c31d4;stroke-width:3.67982411;stroke-linecap:round;stroke-miterlimit:10;stroke-dasharray:none;stroke-opacity:1"
      sodipodi:type="arc"
      sodipodi:cx="352.6825"
      sodipodi:cy="471.689"
@@ -1723,7 +1723,7 @@
   <path
      class="cls-11"
      id="circle209-2-5"
-     style="fill:none;stroke:#88c9d3;stroke-width:3.8735795;stroke-linecap:round;stroke-miterlimit:10;stroke-dasharray:none;stroke-opacity:1"
+     style="fill:none;stroke:#3c31d4;stroke-width:3.8735795;stroke-linecap:round;stroke-miterlimit:10;stroke-dasharray:none;stroke-opacity:1"
      inkscape:transform-center-x="-5.9779584"
      inkscape:transform-center-y="82.061089"
      sodipodi:type="arc"
@@ -1736,19 +1736,19 @@
      d="m 341.04125,546.73464 a 24.789339,24.789339 0 0 1 22.41129,-0.4416 24.789339,24.789339 0 0 1 13.60506,17.8147"
      sodipodi:open="true" />
   <path
-     style="fill:none;fill-rule:evenodd;stroke:#88c9d3;stroke-width:0.81136376;stroke-linecap:butt;stroke-linejoin:miter;stroke-miterlimit:4;stroke-dasharray:none;stroke-opacity:1;marker-start:url(#Arrow1Mstart-2-7)"
+     style="fill:none;fill-rule:evenodd;stroke:#3c31d4;stroke-width:0.81136376;stroke-linecap:butt;stroke-linejoin:miter;stroke-miterlimit:4;stroke-dasharray:none;stroke-opacity:1;marker-start:url(#Arrow1Mstart-2-7)"
      d="m 341.11271,543.00327 0,-48.0619 0,0"
      id="path12354-2-1"
      inkscape:connector-curvature="0" />
   <path
-     style="fill:none;fill-rule:evenodd;stroke:#88c9d3;stroke-width:0.74798137;stroke-linecap:butt;stroke-linejoin:miter;stroke-miterlimit:4;stroke-dasharray:none;stroke-opacity:1;marker-start:url(#Arrow1Mstart-2-90)"
+     style="fill:none;fill-rule:evenodd;stroke:#3c31d4;stroke-width:0.74798137;stroke-linecap:butt;stroke-linejoin:miter;stroke-miterlimit:4;stroke-dasharray:none;stroke-opacity:1;marker-start:url(#Arrow1Mstart-2-90)"
      d="m 243.41418,500.70593 0,40.84609 0,0"
      id="path12354-2-9"
      inkscape:connector-curvature="0" />
   <circle
      class="cls-11"
      id="circle209-2-1"
-     style="fill:none;stroke:#88c9d3;stroke-width:3.8735795;stroke-linecap:round;stroke-miterlimit:10;stroke-dasharray:none;stroke-opacity:1"
+     style="fill:none;stroke:#3c31d4;stroke-width:3.8735795;stroke-linecap:round;stroke-miterlimit:10;stroke-dasharray:none;stroke-opacity:1"
      inkscape:transform-center-x="5.9779443"
      inkscape:transform-center-y="82.061077"
      transform="scale(-1,1)"
@@ -1765,7 +1765,7 @@
   <circle
      class="cls-7"
      id="ellipse25-6-0-0-2"
-     style="fill:none;stroke:#88c9d3;stroke-width:3.67982411;stroke-linecap:round;stroke-miterlimit:10;stroke-dasharray:none;stroke-opacity:1"
+     style="fill:none;stroke:#3c31d4;stroke-width:3.67982411;stroke-linecap:round;stroke-miterlimit:10;stroke-dasharray:none;stroke-opacity:1"
      cx="243.4126"
      cy="471.689"
      r="24.888483" />
@@ -1787,12 +1787,12 @@
        style="color:#000000;font-style:normal;font-variant:normal;font-weight:normal;font-stretch:normal;font-size:8.83800697px;line-height:100%;font-family:Roboto;-inkscape-font-specification:'Roboto, Normal';text-align:end;writing-mode:lr-tb;text-anchor:end;clip-rule:nonzero;display:inline;overflow:visible;visibility:visible;opacity:1;isolation:auto;mix-blend-mode:normal;color-interpolation:sRGB;color-interpolation-filters:linearRGB;solid-color:#000000;solid-opacity:1;fill:#808080;fill-opacity:1;fill-rule:nonzero;stroke:none;stroke-width:1px;stroke-linecap:butt;stroke-linejoin:miter;stroke-miterlimit:4;stroke-dasharray:none;stroke-dashoffset:0;stroke-opacity:1;color-rendering:auto;image-rendering:auto;shape-rendering:auto;text-rendering:auto;enable-background:accumulate"
        id="tspan16590-0">owned by</tspan></text>
   <path
-     style="fill:none;fill-rule:evenodd;stroke:#88c9d3;stroke-width:0.85340309;stroke-linecap:butt;stroke-linejoin:miter;stroke-miterlimit:4;stroke-dasharray:none;stroke-opacity:1;marker-start:url(#Arrow1Mstart-2-90-3)"
+     style="fill:none;fill-rule:evenodd;stroke:#3c31d4;stroke-width:0.85340309;stroke-linecap:butt;stroke-linejoin:miter;stroke-miterlimit:4;stroke-dasharray:none;stroke-opacity:1;marker-start:url(#Arrow1Mstart-2-90-3)"
      d="m 273.09634,571.34985 53.17145,0 0,0"
      id="path12354-2-9-4"
      inkscape:connector-curvature="0" />
   <path
-     style="fill:none;fill-rule:evenodd;stroke:#88c9d3;stroke-width:0.85340309;stroke-linecap:butt;stroke-linejoin:miter;stroke-miterlimit:4;stroke-dasharray:none;stroke-opacity:1;marker-start:url(#Arrow1Mstart-2-90-3-9)"
+     style="fill:none;fill-rule:evenodd;stroke:#3c31d4;stroke-width:0.85340309;stroke-linecap:butt;stroke-linejoin:miter;stroke-miterlimit:4;stroke-dasharray:none;stroke-opacity:1;marker-start:url(#Arrow1Mstart-2-90-3-9)"
      d="m 321.97321,471.68906 -53.17144,0 0,0"
      id="path12354-2-9-4-7"
      inkscape:connector-curvature="0" />
@@ -1840,13 +1840,13 @@
        style="color:#000000;font-style:normal;font-variant:normal;font-weight:normal;font-stretch:normal;font-size:8.83800697px;line-height:100%;font-family:Roboto;-inkscape-font-specification:'Roboto, Normal';text-align:end;writing-mode:lr-tb;text-anchor:end;clip-rule:nonzero;display:inline;overflow:visible;visibility:visible;opacity:1;isolation:auto;mix-blend-mode:normal;color-interpolation:sRGB;color-interpolation-filters:linearRGB;solid-color:#000000;solid-opacity:1;fill:#808080;fill-opacity:1;fill-rule:nonzero;stroke:none;stroke-width:1px;stroke-linecap:butt;stroke-linejoin:miter;stroke-miterlimit:4;stroke-dasharray:none;stroke-dashoffset:0;stroke-opacity:1;color-rendering:auto;image-rendering:auto;shape-rendering:auto;text-rendering:auto;enable-background:accumulate"
        id="tspan16590-0-3">owned by</tspan></text>
   <path
-     style="color:#000000;clip-rule:nonzero;display:inline;overflow:visible;visibility:visible;opacity:1;isolation:auto;mix-blend-mode:normal;color-interpolation:sRGB;color-interpolation-filters:linearRGB;solid-color:#000000;solid-opacity:1;fill:#88c9d3;fill-opacity:1;fill-rule:nonzero;stroke:none;stroke-width:10.19999981;stroke-linecap:butt;stroke-linejoin:miter;stroke-miterlimit:4;stroke-dasharray:none;stroke-dashoffset:0;stroke-opacity:1;color-rendering:auto;image-rendering:auto;shape-rendering:auto;text-rendering:auto;enable-background:accumulate"
+     style="color:#000000;clip-rule:nonzero;display:inline;overflow:visible;visibility:visible;opacity:1;isolation:auto;mix-blend-mode:normal;color-interpolation:sRGB;color-interpolation-filters:linearRGB;solid-color:#000000;solid-opacity:1;fill:#3c31d4;fill-opacity:1;fill-rule:nonzero;stroke:none;stroke-width:10.19999981;stroke-linecap:butt;stroke-linejoin:miter;stroke-miterlimit:4;stroke-dasharray:none;stroke-dashoffset:0;stroke-opacity:1;color-rendering:auto;image-rendering:auto;shape-rendering:auto;text-rendering:auto;enable-background:accumulate"
      d="m 30,286.71979 595.58796,0 0,8.89008 -595.58796,0 z"
      id="rect25703"
      inkscape:connector-curvature="0" />
   <path
      sodipodi:type="star"
-     style="color:#000000;clip-rule:nonzero;display:inline;overflow:visible;visibility:visible;opacity:1;isolation:auto;mix-blend-mode:normal;color-interpolation:sRGB;color-interpolation-filters:linearRGB;solid-color:#000000;solid-opacity:1;fill:#88c9d3;fill-opacity:1;fill-rule:nonzero;stroke:none;stroke-width:10.19999981;stroke-linecap:butt;stroke-linejoin:miter;stroke-miterlimit:4;stroke-dasharray:none;stroke-dashoffset:0;stroke-opacity:1;color-rendering:auto;image-rendering:auto;shape-rendering:auto;text-rendering:auto;enable-background:accumulate"
+     style="color:#000000;clip-rule:nonzero;display:inline;overflow:visible;visibility:visible;opacity:1;isolation:auto;mix-blend-mode:normal;color-interpolation:sRGB;color-interpolation-filters:linearRGB;solid-color:#000000;solid-opacity:1;fill:#3c31d4;fill-opacity:1;fill-rule:nonzero;stroke:none;stroke-width:10.19999981;stroke-linecap:butt;stroke-linejoin:miter;stroke-miterlimit:4;stroke-dasharray:none;stroke-dashoffset:0;stroke-opacity:1;color-rendering:auto;image-rendering:auto;shape-rendering:auto;text-rendering:auto;enable-background:accumulate"
      id="path25710"
      sodipodi:sides="3"
      sodipodi:cx="327.79398"
@@ -1867,7 +1867,7 @@
        transform="translate(204.15572,23.143849)"
        id="g25484-3-9-2">
       <rect
-         style="color:#000000;clip-rule:nonzero;display:inline;overflow:visible;visibility:visible;opacity:1;isolation:auto;mix-blend-mode:normal;color-interpolation:sRGB;color-interpolation-filters:linearRGB;solid-color:#000000;solid-opacity:1;fill:#88c9d3;fill-opacity:1;fill-rule:nonzero;stroke:none;stroke-width:10.19999981;stroke-linecap:butt;stroke-linejoin:miter;stroke-miterlimit:4;stroke-dasharray:none;stroke-dashoffset:0;stroke-opacity:1;color-rendering:auto;image-rendering:auto;shape-rendering:auto;text-rendering:auto;enable-background:accumulate"
+         style="color:#000000;clip-rule:nonzero;display:inline;overflow:visible;visibility:visible;opacity:1;isolation:auto;mix-blend-mode:normal;color-interpolation:sRGB;color-interpolation-filters:linearRGB;solid-color:#000000;solid-opacity:1;fill:#3c31d4;fill-opacity:1;fill-rule:nonzero;stroke:none;stroke-width:10.19999981;stroke-linecap:butt;stroke-linejoin:miter;stroke-miterlimit:4;stroke-dasharray:none;stroke-dashoffset:0;stroke-opacity:1;color-rendering:auto;image-rendering:auto;shape-rendering:auto;text-rendering:auto;enable-background:accumulate"
          id="rect23575-7-0-0"
          width="49.724998"
          height="47.673"
@@ -2029,7 +2029,7 @@
        transform="translate(-19.324739,23.143848)"
        id="g25484">
       <rect
-         style="color:#000000;clip-rule:nonzero;display:inline;overflow:visible;visibility:visible;opacity:1;isolation:auto;mix-blend-mode:normal;color-interpolation:sRGB;color-interpolation-filters:linearRGB;solid-color:#000000;solid-opacity:1;fill:#88c9d3;fill-opacity:1;fill-rule:nonzero;stroke:none;stroke-width:10.19999981;stroke-linecap:butt;stroke-linejoin:miter;stroke-miterlimit:4;stroke-dasharray:none;stroke-dashoffset:0;stroke-opacity:1;color-rendering:auto;image-rendering:auto;shape-rendering:auto;text-rendering:auto;enable-background:accumulate"
+         style="color:#000000;clip-rule:nonzero;display:inline;overflow:visible;visibility:visible;opacity:1;isolation:auto;mix-blend-mode:normal;color-interpolation:sRGB;color-interpolation-filters:linearRGB;solid-color:#000000;solid-opacity:1;fill:#3c31d4;fill-opacity:1;fill-rule:nonzero;stroke:none;stroke-width:10.19999981;stroke-linecap:butt;stroke-linejoin:miter;stroke-miterlimit:4;stroke-dasharray:none;stroke-dashoffset:0;stroke-opacity:1;color-rendering:auto;image-rendering:auto;shape-rendering:auto;text-rendering:auto;enable-background:accumulate"
          id="rect23575"
          width="49.724998"
          height="47.673"
@@ -2263,7 +2263,7 @@
        transform="translate(53.823677,23.143853)"
        id="g25484-3">
       <rect
-         style="color:#000000;clip-rule:nonzero;display:inline;overflow:visible;visibility:visible;opacity:1;isolation:auto;mix-blend-mode:normal;color-interpolation:sRGB;color-interpolation-filters:linearRGB;solid-color:#000000;solid-opacity:1;fill:#88c9d3;fill-opacity:1;fill-rule:nonzero;stroke:none;stroke-width:10.19999981;stroke-linecap:butt;stroke-linejoin:miter;stroke-miterlimit:4;stroke-dasharray:none;stroke-dashoffset:0;stroke-opacity:1;color-rendering:auto;image-rendering:auto;shape-rendering:auto;text-rendering:auto;enable-background:accumulate"
+         style="color:#000000;clip-rule:nonzero;display:inline;overflow:visible;visibility:visible;opacity:1;isolation:auto;mix-blend-mode:normal;color-interpolation:sRGB;color-interpolation-filters:linearRGB;solid-color:#000000;solid-opacity:1;fill:#3c31d4;fill-opacity:1;fill-rule:nonzero;stroke:none;stroke-width:10.19999981;stroke-linecap:butt;stroke-linejoin:miter;stroke-miterlimit:4;stroke-dasharray:none;stroke-dashoffset:0;stroke-opacity:1;color-rendering:auto;image-rendering:auto;shape-rendering:auto;text-rendering:auto;enable-background:accumulate"
          id="rect23575-7"
          width="49.724998"
          height="47.673"
@@ -2449,7 +2449,7 @@
        transform="translate(130.69447,23.143853)"
        id="g25484-3-9">
       <rect
-         style="color:#000000;clip-rule:nonzero;display:inline;overflow:visible;visibility:visible;opacity:1;isolation:auto;mix-blend-mode:normal;color-interpolation:sRGB;color-interpolation-filters:linearRGB;solid-color:#000000;solid-opacity:1;fill:#88c9d3;fill-opacity:1;fill-rule:nonzero;stroke:none;stroke-width:10.19999981;stroke-linecap:butt;stroke-linejoin:miter;stroke-miterlimit:4;stroke-dasharray:none;stroke-dashoffset:0;stroke-opacity:1;color-rendering:auto;image-rendering:auto;shape-rendering:auto;text-rendering:auto;enable-background:accumulate"
+         style="color:#000000;clip-rule:nonzero;display:inline;overflow:visible;visibility:visible;opacity:1;isolation:auto;mix-blend-mode:normal;color-interpolation:sRGB;color-interpolation-filters:linearRGB;solid-color:#000000;solid-opacity:1;fill:#3c31d4;fill-opacity:1;fill-rule:nonzero;stroke:none;stroke-width:10.19999981;stroke-linecap:butt;stroke-linejoin:miter;stroke-miterlimit:4;stroke-dasharray:none;stroke-dashoffset:0;stroke-opacity:1;color-rendering:auto;image-rendering:auto;shape-rendering:auto;text-rendering:auto;enable-background:accumulate"
          id="rect23575-7-0"
          width="49.724998"
          height="47.673"
@@ -2651,7 +2651,7 @@
        id="tspan11868"
        x="36.731651"
        y="317.01624"
-       style="font-style:normal;font-variant:normal;font-weight:bold;font-stretch:normal;font-size:21.79999924px;line-height:125%;font-family:Roboto;-inkscape-font-specification:'Roboto, Bold';text-align:start;letter-spacing:3.09560013px;writing-mode:lr-tb;text-anchor:start;fill:#88c9d3;fill-opacity:1"
+       style="font-style:normal;font-variant:normal;font-weight:bold;font-stretch:normal;font-size:21.79999924px;line-height:125%;font-family:Roboto;-inkscape-font-specification:'Roboto, Bold';text-align:start;letter-spacing:3.09560013px;writing-mode:lr-tb;text-anchor:start;fill:#3c31d4;fill-opacity:1"
        dx="0 0 0 0 0 0 0 0 0 0 0 0 0 0 0">standardised data</tspan></text>
   <path
      style="fill:none;fill-rule:evenodd;stroke:#a92398;stroke-width:2.18000007px;stroke-linecap:butt;stroke-linejoin:miter;stroke-opacity:1;marker-start:url(#marker8745)"

--- a/docs/_assets/Diag9-JSONdata.svg
+++ b/docs/_assets/Diag9-JSONdata.svg
@@ -343,7 +343,7 @@
          y="170.90419" />
     </g>
     <rect
-       style="color:#000000;clip-rule:nonzero;display:inline;overflow:visible;visibility:visible;opacity:0.99100001;isolation:auto;mix-blend-mode:normal;color-interpolation:sRGB;color-interpolation-filters:linearRGB;solid-color:#000000;solid-opacity:1;fill:none;fill-opacity:1;fill-rule:nonzero;stroke:#88c9d3;stroke-width:2.88275409;stroke-linecap:round;stroke-linejoin:miter;stroke-miterlimit:4;stroke-dasharray:none;stroke-dashoffset:0;stroke-opacity:1;color-rendering:auto;image-rendering:auto;shape-rendering:auto;text-rendering:auto;enable-background:accumulate"
+       style="color:#000000;clip-rule:nonzero;display:inline;overflow:visible;visibility:visible;opacity:0.99100001;isolation:auto;mix-blend-mode:normal;color-interpolation:sRGB;color-interpolation-filters:linearRGB;solid-color:#000000;solid-opacity:1;fill:none;fill-opacity:1;fill-rule:nonzero;stroke:#3c31d4;stroke-width:2.88275409;stroke-linecap:round;stroke-linejoin:miter;stroke-miterlimit:4;stroke-dasharray:none;stroke-dashoffset:0;stroke-opacity:1;color-rendering:auto;image-rendering:auto;shape-rendering:auto;text-rendering:auto;enable-background:accumulate"
        id="rect5843-0-5"
        width="1168.6735"
        height="659.32184"
@@ -361,6 +361,6 @@
          id="tspan5492"
          x="979.71808"
          y="809.4538"
-         style="font-style:normal;font-variant:normal;font-weight:bold;font-stretch:normal;font-size:40px;line-height:125%;font-family:Roboto;-inkscape-font-specification:'Roboto, Bold';text-align:start;writing-mode:lr-tb;text-anchor:start;fill:#00788f;fill-opacity:0.94117647">JSON</tspan></text>
+         style="font-style:normal;font-variant:normal;font-weight:bold;font-stretch:normal;font-size:40px;line-height:125%;font-family:Roboto;-inkscape-font-specification:'Roboto, Bold';text-align:start;writing-mode:lr-tb;text-anchor:start;fill:#3c31d4;fill-opacity:0.94117647">JSON</tspan></text>
   </g>
 </svg>

--- a/docs/_assets/data-schema-model-1.svg
+++ b/docs/_assets/data-schema-model-1.svg
@@ -85,7 +85,7 @@
       <path
          id="path4371"
          d="M 0,0 5,-5 -12.5,0 5,5 0,0 Z"
-         style="fill:#00deb6;fill-opacity:1;fill-rule:evenodd;stroke:#00deb6;stroke-width:1pt;stroke-opacity:1"
+         style="fill:#3c31d4;fill-opacity:1;fill-rule:evenodd;stroke:#3c31d4;stroke-width:1pt;stroke-opacity:1"
          transform="matrix(-0.8,0,0,-0.8,-10,0)"
          inkscape:connector-curvature="0" />
     </marker>
@@ -100,7 +100,7 @@
       <path
          id="path4377"
          d="M 0,0 5,-5 -12.5,0 5,5 0,0 Z"
-         style="fill:#00deb6;fill-opacity:1;fill-rule:evenodd;stroke:#00deb6;stroke-width:1pt;stroke-opacity:1"
+         style="fill:#3c31d4;fill-opacity:1;fill-rule:evenodd;stroke:#3c31d4;stroke-width:1pt;stroke-opacity:1"
          transform="matrix(-0.4,0,0,-0.4,-4,0)"
          inkscape:connector-curvature="0" />
     </marker>
@@ -115,12 +115,12 @@
       <path
          id="path4374"
          d="M 0,0 5,-5 -12.5,0 5,5 0,0 Z"
-         style="fill:#88c9d3;fill-opacity:1;fill-rule:evenodd;stroke:#88c9d3;stroke-width:1pt;stroke-opacity:1"
+         style="fill:#3c31d4;fill-opacity:1;fill-rule:evenodd;stroke:#3c31d4;stroke-width:1pt;stroke-opacity:1"
          transform="matrix(0.4,0,0,0.4,4,0)"
          inkscape:connector-curvature="0" />
     </marker>
     <style
-       id="style5">.cls-1,.cls-10,.cls-11,.cls-7,.cls-8{fill:none;}.cls-1,.cls-11{stroke:#00deb6;}.cls-1,.cls-10,.cls-11,.cls-7{stroke-miterlimit:10;}.cls-2{fill:#00deb6;}.cls-3{font-size:16px;fill:#262737;}.cls-12,.cls-3{font-family:HKGrotesk-SemiBold, HK Grotesk;font-weight:700;}.cls-4{letter-spacing:-0.03em;}.cls-5{letter-spacing:-0.02em;}.cls-6{letter-spacing:0em;}.cls-7{stroke:#262737;}.cls-11,.cls-7{stroke-width:5px;}.cls-9{letter-spacing:-0.01em;}.cls-10{stroke:#e6e6e6;}.cls-12{font-size:12px;fill:gray;}.cls-13{letter-spacing:-0.03em;}.cls-14{letter-spacing:-0.01em;}.cls-15{letter-spacing:-0.02em;}.cls-16{letter-spacing:0em;}.cls-17{letter-spacing:0em;}.cls-18{letter-spacing:0em;}</style>
+       id="style5">.cls-1,.cls-10,.cls-11,.cls-7,.cls-8{fill:none;}.cls-1,.cls-11{stroke:#3c31d4;}.cls-1,.cls-10,.cls-11,.cls-7{stroke-miterlimit:10;}.cls-2{fill:#3c31d4;}.cls-3{font-size:16px;fill:#262737;}.cls-12,.cls-3{font-family:HKGrotesk-SemiBold, HK Grotesk;font-weight:700;}.cls-4{letter-spacing:-0.03em;}.cls-5{letter-spacing:-0.02em;}.cls-6{letter-spacing:0em;}.cls-7{stroke:#262737;}.cls-11,.cls-7{stroke-width:5px;}.cls-9{letter-spacing:-0.01em;}.cls-10{stroke:#e6e6e6;}.cls-12{font-size:12px;fill:gray;}.cls-13{letter-spacing:-0.03em;}.cls-14{letter-spacing:-0.01em;}.cls-15{letter-spacing:-0.02em;}.cls-16{letter-spacing:0em;}.cls-17{letter-spacing:0em;}.cls-18{letter-spacing:0em;}</style>
     <marker
        inkscape:stockid="Arrow1Mstart"
        orient="auto"
@@ -133,7 +133,7 @@
          inkscape:connector-curvature="0"
          id="path4374-0"
          d="M 0,0 5,-5 -12.5,0 5,5 0,0 Z"
-         style="fill:#88c9d3;fill-opacity:1;fill-rule:evenodd;stroke:#88c9d3;stroke-width:1pt;stroke-opacity:1"
+         style="fill:#3c31d4;fill-opacity:1;fill-rule:evenodd;stroke:#3c31d4;stroke-width:1pt;stroke-opacity:1"
          transform="matrix(0.4,0,0,0.4,4,0)" />
     </marker>
     <clipPath
@@ -196,7 +196,7 @@
          inkscape:connector-curvature="0"
          id="path4374-0-0"
          d="M 0,0 5,-5 -12.5,0 5,5 0,0 Z"
-         style="fill:#00deb6;fill-opacity:1;fill-rule:evenodd;stroke:#00deb6;stroke-width:1pt;stroke-opacity:1"
+         style="fill:#3c31d4;fill-opacity:1;fill-rule:evenodd;stroke:#3c31d4;stroke-width:1pt;stroke-opacity:1"
          transform="matrix(0.4,0,0,0.4,4,0)" />
     </marker>
     <marker
@@ -210,7 +210,7 @@
       <path
          id="path4374-9"
          d="M 0,0 5,-5 -12.5,0 5,5 0,0 Z"
-         style="fill:#00deb6;fill-opacity:1;fill-rule:evenodd;stroke:#00deb6;stroke-width:1pt;stroke-opacity:1"
+         style="fill:#3c31d4;fill-opacity:1;fill-rule:evenodd;stroke:#3c31d4;stroke-width:1pt;stroke-opacity:1"
          transform="matrix(0.4,0,0,0.4,4,0)"
          inkscape:connector-curvature="0" />
     </marker>
@@ -226,7 +226,7 @@
          inkscape:connector-curvature="0"
          id="path4374-0-9"
          d="M 0,0 5,-5 -12.5,0 5,5 0,0 Z"
-         style="fill:#88c9d3;fill-opacity:1;fill-rule:evenodd;stroke:#88c9d3;stroke-width:1pt;stroke-opacity:1"
+         style="fill:#3c31d4;fill-opacity:1;fill-rule:evenodd;stroke:#3c31d4;stroke-width:1pt;stroke-opacity:1"
          transform="matrix(0.4,0,0,0.4,4,0)" />
     </marker>
     <marker
@@ -241,14 +241,14 @@
          inkscape:connector-curvature="0"
          id="path4374-0-9-9"
          d="M 0,0 5,-5 -12.5,0 5,5 0,0 Z"
-         style="fill:#88c9d3;fill-opacity:1;fill-rule:evenodd;stroke:#88c9d3;stroke-width:1pt;stroke-opacity:1"
+         style="fill:#3c31d4;fill-opacity:1;fill-rule:evenodd;stroke:#3c31d4;stroke-width:1pt;stroke-opacity:1"
          transform="matrix(0.4,0,0,0.4,4,0)" />
     </marker>
   </defs>
   <title
      id="title7">Artboard 1 copy</title>
   <rect
-     style="fill:#f7f7f7;fill-opacity:1;stroke:#88c9d3;stroke-width:1;stroke-linecap:round;stroke-linejoin:round;stroke-miterlimit:10;stroke-dasharray:none;stroke-opacity:1"
+     style="fill:#f7f7f7;fill-opacity:1;stroke:#3c31d4;stroke-width:1;stroke-linecap:round;stroke-linejoin:round;stroke-miterlimit:10;stroke-dasharray:none;stroke-opacity:1"
      id="rect11772"
      width="330"
      height="189.92737"
@@ -257,7 +257,7 @@
   <circle
      class="cls-11"
      id="circle209-2-0-1"
-     style="fill:#ffffff;fill-opacity:1;stroke:#88c9d3;stroke-width:3.75;stroke-linecap:round;stroke-miterlimit:8.5;stroke-dasharray:none;stroke-opacity:1"
+     style="fill:#ffffff;fill-opacity:1;stroke:#3c31d4;stroke-width:3.75;stroke-linecap:round;stroke-miterlimit:8.5;stroke-dasharray:none;stroke-opacity:1"
      inkscape:transform-center-x="-7.2470959"
      inkscape:transform-center-y="99.482843"
      cx="61.94891"
@@ -266,7 +266,7 @@
   <path
      class="cls-11"
      id="circle209-7-4"
-     style="fill:none;stroke:#88c9d3;stroke-width:3.75;stroke-linecap:round;stroke-miterlimit:8.5;stroke-dasharray:none;stroke-opacity:1"
+     style="fill:none;stroke:#3c31d4;stroke-width:3.75;stroke-linecap:round;stroke-miterlimit:8.5;stroke-dasharray:none;stroke-opacity:1"
      inkscape:transform-center-x="-5.4824618"
      inkscape:transform-center-y="75.259237"
      sodipodi:type="arc"
@@ -283,7 +283,7 @@
      d="M 347.06781,56.625781 Z"
      id="path11-6"
      inkscape:connector-curvature="0"
-     style="fill:#00deb6" />
+     style="fill:#3c31d4" />
   <path
      d="m 347.06781,56.625781 0,0 m 0,0 0,0 m 0,0 z m 0,0 z"
      id="path27-3"
@@ -411,43 +411,43 @@
      d="m 347.06781,56.625781 0,0"
      id="path79-9"
      inkscape:connector-curvature="0"
-     style="fill:none;stroke:#00deb6;stroke-width:5px;stroke-miterlimit:10" />
+     style="fill:none;stroke:#3c31d4;stroke-width:5px;stroke-miterlimit:10" />
   <path
      class="cls-11"
      d="m 347.06781,56.625781 0,0"
      id="path85-7"
      inkscape:connector-curvature="0"
-     style="fill:none;stroke:#00deb6;stroke-width:5px;stroke-miterlimit:10" />
+     style="fill:none;stroke:#3c31d4;stroke-width:5px;stroke-miterlimit:10" />
   <path
      class="cls-11"
      d="m 347.06781,56.625781 0,0"
      id="path87-8"
      inkscape:connector-curvature="0"
-     style="fill:none;stroke:#00deb6;stroke-width:5px;stroke-miterlimit:10" />
+     style="fill:none;stroke:#3c31d4;stroke-width:5px;stroke-miterlimit:10" />
   <path
      class="cls-11"
      d="m 347.06781,56.625781 0,0"
      id="path89-3"
      inkscape:connector-curvature="0"
-     style="fill:none;stroke:#00deb6;stroke-width:5px;stroke-miterlimit:10" />
+     style="fill:none;stroke:#3c31d4;stroke-width:5px;stroke-miterlimit:10" />
   <path
      class="cls-11"
      d="m 347.06781,56.625781 0,0"
      id="path91-9"
      inkscape:connector-curvature="0"
-     style="fill:none;stroke:#00deb6;stroke-width:5px;stroke-miterlimit:10" />
+     style="fill:none;stroke:#3c31d4;stroke-width:5px;stroke-miterlimit:10" />
   <path
      class="cls-11"
      d="m 347.06781,56.625781 0,0"
      id="path93-7"
      inkscape:connector-curvature="0"
-     style="fill:none;stroke:#00deb6;stroke-width:5px;stroke-miterlimit:10" />
+     style="fill:none;stroke:#3c31d4;stroke-width:5px;stroke-miterlimit:10" />
   <path
      class="cls-11"
      d="m 347.06781,56.625781 0,0"
      id="path95-2"
      inkscape:connector-curvature="0"
-     style="fill:none;stroke:#00deb6;stroke-width:5px;stroke-miterlimit:10" />
+     style="fill:none;stroke:#3c31d4;stroke-width:5px;stroke-miterlimit:10" />
   <path
      class="cls-10"
      d="m 347.06781,56.625781 0,0"
@@ -525,13 +525,13 @@
      d="M 347.06781,56.625781 Z"
      id="path171-1"
      inkscape:connector-curvature="0"
-     style="fill:#00deb6" />
+     style="fill:#3c31d4" />
   <path
      class="cls-2"
      d="M 347.06781,56.625781 Z"
      id="path197-3"
      inkscape:connector-curvature="0"
-     style="fill:#00deb6" />
+     style="fill:#3c31d4" />
   <path
      class="cls-8"
      d="M 347.06781,56.625781 Z"
@@ -549,14 +549,14 @@
   <circle
      class="cls-11"
      id="circle209-2-0-1-7"
-     style="fill:#ffffff;fill-opacity:1;stroke:#88c9d3;stroke-width:3.75;stroke-linecap:round;stroke-miterlimit:8.5;stroke-dasharray:none;stroke-opacity:1"
+     style="fill:#ffffff;fill-opacity:1;stroke:#3c31d4;stroke-width:3.75;stroke-linecap:round;stroke-miterlimit:8.5;stroke-dasharray:none;stroke-opacity:1"
      inkscape:transform-center-x="-7.2470929"
      inkscape:transform-center-y="99.48285"
      cx="61.927174"
      cy="61.927174"
      r="30.052174" />
   <path
-     style="fill:none;fill-rule:evenodd;stroke:#88c9d3;stroke-width:3.75;stroke-linecap:butt;stroke-linejoin:miter;stroke-miterlimit:8.5;stroke-dasharray:none;stroke-opacity:1"
+     style="fill:none;fill-rule:evenodd;stroke:#3c31d4;stroke-width:3.75;stroke-linecap:butt;stroke-linejoin:miter;stroke-miterlimit:8.5;stroke-dasharray:none;stroke-opacity:1"
      d="m 61.927177,91.979345 1.2e-5,85.867835 0.01592,44.42002"
      id="path12354-2-8-1"
      inkscape:connector-curvature="0"
@@ -574,14 +574,14 @@
        height="57.937305"
        width="247.79369"
        id="rect11772-8"
-       style="fill:#ffffff;fill-opacity:1;stroke:#88c9d3;stroke-width:1;stroke-linecap:round;stroke-linejoin:round;stroke-miterlimit:10;stroke-dasharray:none;stroke-opacity:1" />
+       style="fill:#ffffff;fill-opacity:1;stroke:#3c31d4;stroke-width:1;stroke-linecap:round;stroke-linejoin:round;stroke-miterlimit:10;stroke-dasharray:none;stroke-opacity:1" />
     <rect
        y="77.933228"
        x="124.7962"
        height="57.937305"
        width="23.889727"
        id="rect9705"
-       style="color:#000000;clip-rule:nonzero;display:inline;overflow:visible;visibility:visible;opacity:1;isolation:auto;mix-blend-mode:normal;color-interpolation:sRGB;color-interpolation-filters:linearRGB;solid-color:#000000;solid-opacity:1;fill:#88c9d3;fill-opacity:1;fill-rule:nonzero;stroke:none;stroke-width:1;stroke-linecap:round;stroke-linejoin:miter;stroke-miterlimit:10;stroke-dasharray:none;stroke-dashoffset:0;stroke-opacity:1;color-rendering:auto;image-rendering:auto;shape-rendering:auto;text-rendering:auto;enable-background:accumulate" />
+       style="color:#000000;clip-rule:nonzero;display:inline;overflow:visible;visibility:visible;opacity:1;isolation:auto;mix-blend-mode:normal;color-interpolation:sRGB;color-interpolation-filters:linearRGB;solid-color:#000000;solid-opacity:1;fill:#3c31d4;fill-opacity:1;fill-rule:nonzero;stroke:none;stroke-width:1;stroke-linecap:round;stroke-linejoin:miter;stroke-miterlimit:10;stroke-dasharray:none;stroke-dashoffset:0;stroke-opacity:1;color-rendering:auto;image-rendering:auto;shape-rendering:auto;text-rendering:auto;enable-background:accumulate" />
     <text
        transform="matrix(0,-1,1,0,0,0)"
        y="141.55826"
@@ -647,14 +647,14 @@
        height="57.937305"
        width="247.79369"
        id="rect11772-8-5"
-       style="fill:#ffffff;fill-opacity:1;stroke:#88c9d3;stroke-width:1;stroke-linecap:round;stroke-linejoin:round;stroke-miterlimit:10;stroke-dasharray:none;stroke-opacity:1" />
+       style="fill:#ffffff;fill-opacity:1;stroke:#3c31d4;stroke-width:1;stroke-linecap:round;stroke-linejoin:round;stroke-miterlimit:10;stroke-dasharray:none;stroke-opacity:1" />
     <rect
        y="322.54688"
        x="261.33011"
        height="57.937305"
        width="23.889727"
        id="rect9705-6"
-       style="color:#000000;clip-rule:nonzero;display:inline;overflow:visible;visibility:visible;opacity:1;isolation:auto;mix-blend-mode:normal;color-interpolation:sRGB;color-interpolation-filters:linearRGB;solid-color:#000000;solid-opacity:1;fill:#88c9d3;fill-opacity:1;fill-rule:nonzero;stroke:none;stroke-width:1;stroke-linecap:round;stroke-linejoin:miter;stroke-miterlimit:10;stroke-dasharray:none;stroke-dashoffset:0;stroke-opacity:1;color-rendering:auto;image-rendering:auto;shape-rendering:auto;text-rendering:auto;enable-background:accumulate" />
+       style="color:#000000;clip-rule:nonzero;display:inline;overflow:visible;visibility:visible;opacity:1;isolation:auto;mix-blend-mode:normal;color-interpolation:sRGB;color-interpolation-filters:linearRGB;solid-color:#000000;solid-opacity:1;fill:#3c31d4;fill-opacity:1;fill-rule:nonzero;stroke:none;stroke-width:1;stroke-linecap:round;stroke-linejoin:miter;stroke-miterlimit:10;stroke-dasharray:none;stroke-dashoffset:0;stroke-opacity:1;color-rendering:auto;image-rendering:auto;shape-rendering:auto;text-rendering:auto;enable-background:accumulate" />
     <text
        transform="matrix(0,-1,1,0,0,0)"
        y="278.09216"

--- a/docs/_assets/data-schema-model-2.svg
+++ b/docs/_assets/data-schema-model-2.svg
@@ -85,7 +85,7 @@
       <path
          id="path4371"
          d="M 0,0 5,-5 -12.5,0 5,5 0,0 Z"
-         style="fill:#00deb6;fill-opacity:1;fill-rule:evenodd;stroke:#00deb6;stroke-width:1pt;stroke-opacity:1"
+         style="fill:#3c31d4;fill-opacity:1;fill-rule:evenodd;stroke:#3c31d4;stroke-width:1pt;stroke-opacity:1"
          transform="matrix(-0.8,0,0,-0.8,-10,0)"
          inkscape:connector-curvature="0" />
     </marker>
@@ -100,7 +100,7 @@
       <path
          id="path4377"
          d="M 0,0 5,-5 -12.5,0 5,5 0,0 Z"
-         style="fill:#00deb6;fill-opacity:1;fill-rule:evenodd;stroke:#00deb6;stroke-width:1pt;stroke-opacity:1"
+         style="fill:#3c31d4;fill-opacity:1;fill-rule:evenodd;stroke:#3c31d4;stroke-width:1pt;stroke-opacity:1"
          transform="matrix(-0.4,0,0,-0.4,-4,0)"
          inkscape:connector-curvature="0" />
     </marker>
@@ -115,12 +115,12 @@
       <path
          id="path4374"
          d="M 0,0 5,-5 -12.5,0 5,5 0,0 Z"
-         style="fill:#88c9d3;fill-opacity:1;fill-rule:evenodd;stroke:#88c9d3;stroke-width:1pt;stroke-opacity:1"
+         style="fill:#3c31d4;fill-opacity:1;fill-rule:evenodd;stroke:#3c31d4;stroke-width:1pt;stroke-opacity:1"
          transform="matrix(0.4,0,0,0.4,4,0)"
          inkscape:connector-curvature="0" />
     </marker>
     <style
-       id="style5">.cls-1,.cls-10,.cls-11,.cls-7,.cls-8{fill:none;}.cls-1,.cls-11{stroke:#00deb6;}.cls-1,.cls-10,.cls-11,.cls-7{stroke-miterlimit:10;}.cls-2{fill:#00deb6;}.cls-3{font-size:16px;fill:#262737;}.cls-12,.cls-3{font-family:HKGrotesk-SemiBold, HK Grotesk;font-weight:700;}.cls-4{letter-spacing:-0.03em;}.cls-5{letter-spacing:-0.02em;}.cls-6{letter-spacing:0em;}.cls-7{stroke:#262737;}.cls-11,.cls-7{stroke-width:5px;}.cls-9{letter-spacing:-0.01em;}.cls-10{stroke:#e6e6e6;}.cls-12{font-size:12px;fill:gray;}.cls-13{letter-spacing:-0.03em;}.cls-14{letter-spacing:-0.01em;}.cls-15{letter-spacing:-0.02em;}.cls-16{letter-spacing:0em;}.cls-17{letter-spacing:0em;}.cls-18{letter-spacing:0em;}</style>
+       id="style5">.cls-1,.cls-10,.cls-11,.cls-7,.cls-8{fill:none;}.cls-1,.cls-11{stroke:#3c31d4;}.cls-1,.cls-10,.cls-11,.cls-7{stroke-miterlimit:10;}.cls-2{fill:#3c31d4;}.cls-3{font-size:16px;fill:#262737;}.cls-12,.cls-3{font-family:HKGrotesk-SemiBold, HK Grotesk;font-weight:700;}.cls-4{letter-spacing:-0.03em;}.cls-5{letter-spacing:-0.02em;}.cls-6{letter-spacing:0em;}.cls-7{stroke:#262737;}.cls-11,.cls-7{stroke-width:5px;}.cls-9{letter-spacing:-0.01em;}.cls-10{stroke:#e6e6e6;}.cls-12{font-size:12px;fill:gray;}.cls-13{letter-spacing:-0.03em;}.cls-14{letter-spacing:-0.01em;}.cls-15{letter-spacing:-0.02em;}.cls-16{letter-spacing:0em;}.cls-17{letter-spacing:0em;}.cls-18{letter-spacing:0em;}</style>
     <marker
        inkscape:stockid="Arrow1Mstart"
        orient="auto"
@@ -133,7 +133,7 @@
          inkscape:connector-curvature="0"
          id="path4374-0"
          d="M 0,0 5,-5 -12.5,0 5,5 0,0 Z"
-         style="fill:#88c9d3;fill-opacity:1;fill-rule:evenodd;stroke:#88c9d3;stroke-width:1pt;stroke-opacity:1"
+         style="fill:#3c31d4;fill-opacity:1;fill-rule:evenodd;stroke:#3c31d4;stroke-width:1pt;stroke-opacity:1"
          transform="matrix(0.4,0,0,0.4,4,0)" />
     </marker>
     <clipPath
@@ -196,7 +196,7 @@
          inkscape:connector-curvature="0"
          id="path4374-0-0"
          d="M 0,0 5,-5 -12.5,0 5,5 0,0 Z"
-         style="fill:#00deb6;fill-opacity:1;fill-rule:evenodd;stroke:#00deb6;stroke-width:1pt;stroke-opacity:1"
+         style="fill:#3c31d4;fill-opacity:1;fill-rule:evenodd;stroke:#3c31d4;stroke-width:1pt;stroke-opacity:1"
          transform="matrix(0.4,0,0,0.4,4,0)" />
     </marker>
     <marker
@@ -210,7 +210,7 @@
       <path
          id="path4374-9"
          d="M 0,0 5,-5 -12.5,0 5,5 0,0 Z"
-         style="fill:#00deb6;fill-opacity:1;fill-rule:evenodd;stroke:#00deb6;stroke-width:1pt;stroke-opacity:1"
+         style="fill:#3c31d4;fill-opacity:1;fill-rule:evenodd;stroke:#3c31d4;stroke-width:1pt;stroke-opacity:1"
          transform="matrix(0.4,0,0,0.4,4,0)"
          inkscape:connector-curvature="0" />
     </marker>
@@ -226,7 +226,7 @@
          inkscape:connector-curvature="0"
          id="path4374-0-9"
          d="M 0,0 5,-5 -12.5,0 5,5 0,0 Z"
-         style="fill:#88c9d3;fill-opacity:1;fill-rule:evenodd;stroke:#88c9d3;stroke-width:1pt;stroke-opacity:1"
+         style="fill:#3c31d4;fill-opacity:1;fill-rule:evenodd;stroke:#3c31d4;stroke-width:1pt;stroke-opacity:1"
          transform="matrix(0.4,0,0,0.4,4,0)" />
     </marker>
     <marker
@@ -241,14 +241,14 @@
          inkscape:connector-curvature="0"
          id="path4374-0-9-9"
          d="M 0,0 5,-5 -12.5,0 5,5 0,0 Z"
-         style="fill:#88c9d3;fill-opacity:1;fill-rule:evenodd;stroke:#88c9d3;stroke-width:1pt;stroke-opacity:1"
+         style="fill:#3c31d4;fill-opacity:1;fill-rule:evenodd;stroke:#3c31d4;stroke-width:1pt;stroke-opacity:1"
          transform="matrix(0.4,0,0,0.4,4,0)" />
     </marker>
   </defs>
   <title
      id="title7">Artboard 1 copy</title>
   <rect
-     style="fill:#f7f7f7;fill-opacity:1;stroke:#88c9d3;stroke-width:1;stroke-linecap:round;stroke-linejoin:round;stroke-miterlimit:10;stroke-dasharray:none;stroke-opacity:1"
+     style="fill:#f7f7f7;fill-opacity:1;stroke:#3c31d4;stroke-width:1;stroke-linecap:round;stroke-linejoin:round;stroke-miterlimit:10;stroke-dasharray:none;stroke-opacity:1"
      id="rect11772"
      width="330"
      height="189.92737"
@@ -257,7 +257,7 @@
   <path
      class="cls-11"
      id="circle209-2-0-1"
-     style="fill:#ffffff;fill-opacity:1;stroke:#88c9d3;stroke-width:3.75;stroke-linecap:round;stroke-miterlimit:8.5;stroke-dasharray:none;stroke-opacity:1"
+     style="fill:#ffffff;fill-opacity:1;stroke:#3c31d4;stroke-width:3.75;stroke-linecap:round;stroke-miterlimit:8.5;stroke-dasharray:none;stroke-opacity:1"
      inkscape:transform-center-x="-7.2470959"
      inkscape:transform-center-y="99.482843"
      sodipodi:type="arc"
@@ -272,7 +272,7 @@
   <path
      class="cls-11"
      id="circle209-7-4"
-     style="fill:none;stroke:#88c9d3;stroke-width:3.75;stroke-linecap:round;stroke-miterlimit:8.5;stroke-dasharray:none;stroke-opacity:1"
+     style="fill:none;stroke:#3c31d4;stroke-width:3.75;stroke-linecap:round;stroke-miterlimit:8.5;stroke-dasharray:none;stroke-opacity:1"
      inkscape:transform-center-x="-5.4824618"
      inkscape:transform-center-y="75.259237"
      sodipodi:type="arc"
@@ -289,7 +289,7 @@
      d="M 347.54442,239.80881 Z"
      id="path11-6"
      inkscape:connector-curvature="0"
-     style="fill:#00deb6" />
+     style="fill:#3c31d4" />
   <path
      d="m 347.54442,239.80881 0,0 m 0,0 0,0 m 0,0 z m 0,0 z"
      id="path27-3"
@@ -417,43 +417,43 @@
      d="m 347.54442,239.80881 0,0"
      id="path79-9"
      inkscape:connector-curvature="0"
-     style="fill:none;stroke:#00deb6;stroke-width:5px;stroke-miterlimit:10" />
+     style="fill:none;stroke:#3c31d4;stroke-width:5px;stroke-miterlimit:10" />
   <path
      class="cls-11"
      d="m 347.54442,239.80881 0,0"
      id="path85-7"
      inkscape:connector-curvature="0"
-     style="fill:none;stroke:#00deb6;stroke-width:5px;stroke-miterlimit:10" />
+     style="fill:none;stroke:#3c31d4;stroke-width:5px;stroke-miterlimit:10" />
   <path
      class="cls-11"
      d="m 347.54442,239.80881 0,0"
      id="path87-8"
      inkscape:connector-curvature="0"
-     style="fill:none;stroke:#00deb6;stroke-width:5px;stroke-miterlimit:10" />
+     style="fill:none;stroke:#3c31d4;stroke-width:5px;stroke-miterlimit:10" />
   <path
      class="cls-11"
      d="m 347.54442,239.80881 0,0"
      id="path89-3"
      inkscape:connector-curvature="0"
-     style="fill:none;stroke:#00deb6;stroke-width:5px;stroke-miterlimit:10" />
+     style="fill:none;stroke:#3c31d4;stroke-width:5px;stroke-miterlimit:10" />
   <path
      class="cls-11"
      d="m 347.54442,239.80881 0,0"
      id="path91-9"
      inkscape:connector-curvature="0"
-     style="fill:none;stroke:#00deb6;stroke-width:5px;stroke-miterlimit:10" />
+     style="fill:none;stroke:#3c31d4;stroke-width:5px;stroke-miterlimit:10" />
   <path
      class="cls-11"
      d="m 347.54442,239.80881 0,0"
      id="path93-7"
      inkscape:connector-curvature="0"
-     style="fill:none;stroke:#00deb6;stroke-width:5px;stroke-miterlimit:10" />
+     style="fill:none;stroke:#3c31d4;stroke-width:5px;stroke-miterlimit:10" />
   <path
      class="cls-11"
      d="m 347.54442,239.80881 0,0"
      id="path95-2"
      inkscape:connector-curvature="0"
-     style="fill:none;stroke:#00deb6;stroke-width:5px;stroke-miterlimit:10" />
+     style="fill:none;stroke:#3c31d4;stroke-width:5px;stroke-miterlimit:10" />
   <path
      class="cls-10"
      d="m 347.54442,239.80881 0,0"
@@ -531,13 +531,13 @@
      d="M 347.54442,239.80881 Z"
      id="path171-1"
      inkscape:connector-curvature="0"
-     style="fill:#00deb6" />
+     style="fill:#3c31d4" />
   <path
      class="cls-2"
      d="M 347.54442,239.80881 Z"
      id="path197-3"
      inkscape:connector-curvature="0"
-     style="fill:#00deb6" />
+     style="fill:#3c31d4" />
   <path
      class="cls-8"
      d="M 347.54442,239.80881 Z"
@@ -551,7 +551,7 @@
   <path
      class="cls-11"
      id="circle209-2-0-1-7"
-     style="fill:#ffffff;fill-opacity:1;stroke:#88c9d3;stroke-width:3.75;stroke-linecap:round;stroke-miterlimit:8.5;stroke-dasharray:none;stroke-opacity:1"
+     style="fill:#ffffff;fill-opacity:1;stroke:#3c31d4;stroke-width:3.75;stroke-linecap:round;stroke-miterlimit:8.5;stroke-dasharray:none;stroke-opacity:1"
      inkscape:transform-center-x="-7.2470929"
      inkscape:transform-center-y="99.48285"
      sodipodi:type="arc"
@@ -564,13 +564,13 @@
      d="m 88.429727,230.08411 a 30.052174,30.052174 0 0 1 -6.70878,38.04739 30.052174,30.052174 0 0 1 -38.634329,0 30.052174,30.052174 0 0 1 -6.708782,-38.04739"
      sodipodi:open="true" />
   <path
-     style="fill:none;fill-rule:evenodd;stroke:#88c9d3;stroke-width:3.75;stroke-linecap:butt;stroke-linejoin:miter;stroke-miterlimit:8.5;stroke-dasharray:none;stroke-opacity:1"
+     style="fill:none;fill-rule:evenodd;stroke:#3c31d4;stroke-width:3.75;stroke-linecap:butt;stroke-linejoin:miter;stroke-miterlimit:8.5;stroke-dasharray:none;stroke-opacity:1"
      d="m 62.403785,275.16237 1.2e-5,85.86784 0.01592,44.42002"
      id="path12354-2-8-1"
      inkscape:connector-curvature="0"
      sodipodi:nodetypes="ccc" />
   <rect
-     style="fill:#ffffff;fill-opacity:1;stroke:#88c9d3;stroke-width:1;stroke-linecap:round;stroke-linejoin:round;stroke-miterlimit:10;stroke-dasharray:none;stroke-opacity:1"
+     style="fill:#ffffff;fill-opacity:1;stroke:#3c31d4;stroke-width:1;stroke-linecap:round;stroke-linejoin:round;stroke-miterlimit:10;stroke-dasharray:none;stroke-opacity:1"
      id="rect11772-8"
      width="247.79369"
      height="35"
@@ -618,7 +618,7 @@
        id="tspan9875"
        sodipodi:role="line">Ownership-or-control statement</tspan></text>
   <rect
-     style="fill:#ffffff;fill-opacity:1;stroke:#88c9d3;stroke-width:0.78002417;stroke-linecap:round;stroke-linejoin:round;stroke-miterlimit:10;stroke-dasharray:none;stroke-opacity:1"
+     style="fill:#ffffff;fill-opacity:1;stroke:#3c31d4;stroke-width:0.78002417;stroke-linecap:round;stroke-linejoin:round;stroke-miterlimit:10;stroke-dasharray:none;stroke-opacity:1"
      id="rect11772-8-5"
      width="248.01366"
      height="35.219975"
@@ -668,7 +668,7 @@
        style="font-style:normal;font-variant:normal;font-weight:bold;font-stretch:normal;font-size:13.75px;line-height:125%;font-family:Roboto;-inkscape-font-specification:'Roboto, Bold';text-align:start;writing-mode:lr-tb;text-anchor:start;fill:#1f1f1f;fill-opacity:1">interests</tspan>
   </text>
   <path
-     style="fill:none;fill-rule:evenodd;stroke:#88c9d3;stroke-width:1;stroke-linecap:butt;stroke-linejoin:miter;stroke-miterlimit:4;stroke-dasharray:1, 1;stroke-dashoffset:0;stroke-opacity:1"
+     style="fill:none;fill-rule:evenodd;stroke:#3c31d4;stroke-width:1;stroke-linecap:butt;stroke-linejoin:miter;stroke-miterlimit:4;stroke-dasharray:1, 1;stroke-dashoffset:0;stroke-opacity:1"
      d="m 115.52664,348.07055 247.794,0"
      id="path9962"
      inkscape:connector-curvature="0" />

--- a/docs/_assets/data-schema-model-3.svg
+++ b/docs/_assets/data-schema-model-3.svg
@@ -85,7 +85,7 @@
       <path
          id="path4371"
          d="M 0,0 5,-5 -12.5,0 5,5 0,0 Z"
-         style="fill:#00deb6;fill-opacity:1;fill-rule:evenodd;stroke:#00deb6;stroke-width:1pt;stroke-opacity:1"
+         style="fill:#3c31d4;fill-opacity:1;fill-rule:evenodd;stroke:#3c31d4;stroke-width:1pt;stroke-opacity:1"
          transform="matrix(-0.8,0,0,-0.8,-10,0)"
          inkscape:connector-curvature="0" />
     </marker>
@@ -100,7 +100,7 @@
       <path
          id="path4377"
          d="M 0,0 5,-5 -12.5,0 5,5 0,0 Z"
-         style="fill:#00deb6;fill-opacity:1;fill-rule:evenodd;stroke:#00deb6;stroke-width:1pt;stroke-opacity:1"
+         style="fill:#3c31d4;fill-opacity:1;fill-rule:evenodd;stroke:#3c31d4;stroke-width:1pt;stroke-opacity:1"
          transform="matrix(-0.4,0,0,-0.4,-4,0)"
          inkscape:connector-curvature="0" />
     </marker>
@@ -115,12 +115,12 @@
       <path
          id="path4374"
          d="M 0,0 5,-5 -12.5,0 5,5 0,0 Z"
-         style="fill:#88c9d3;fill-opacity:1;fill-rule:evenodd;stroke:#88c9d3;stroke-width:1pt;stroke-opacity:1"
+         style="fill:#3c31d4;fill-opacity:1;fill-rule:evenodd;stroke:#3c31d4;stroke-width:1pt;stroke-opacity:1"
          transform="matrix(0.4,0,0,0.4,4,0)"
          inkscape:connector-curvature="0" />
     </marker>
     <style
-       id="style5">.cls-1,.cls-10,.cls-11,.cls-7,.cls-8{fill:none;}.cls-1,.cls-11{stroke:#00deb6;}.cls-1,.cls-10,.cls-11,.cls-7{stroke-miterlimit:10;}.cls-2{fill:#00deb6;}.cls-3{font-size:16px;fill:#262737;}.cls-12,.cls-3{font-family:HKGrotesk-SemiBold, HK Grotesk;font-weight:700;}.cls-4{letter-spacing:-0.03em;}.cls-5{letter-spacing:-0.02em;}.cls-6{letter-spacing:0em;}.cls-7{stroke:#262737;}.cls-11,.cls-7{stroke-width:5px;}.cls-9{letter-spacing:-0.01em;}.cls-10{stroke:#e6e6e6;}.cls-12{font-size:12px;fill:gray;}.cls-13{letter-spacing:-0.03em;}.cls-14{letter-spacing:-0.01em;}.cls-15{letter-spacing:-0.02em;}.cls-16{letter-spacing:0em;}.cls-17{letter-spacing:0em;}.cls-18{letter-spacing:0em;}</style>
+       id="style5">.cls-1,.cls-10,.cls-11,.cls-7,.cls-8{fill:none;}.cls-1,.cls-11{stroke:#3c31d4;}.cls-1,.cls-10,.cls-11,.cls-7{stroke-miterlimit:10;}.cls-2{fill:#3c31d4;}.cls-3{font-size:16px;fill:#262737;}.cls-12,.cls-3{font-family:HKGrotesk-SemiBold, HK Grotesk;font-weight:700;}.cls-4{letter-spacing:-0.03em;}.cls-5{letter-spacing:-0.02em;}.cls-6{letter-spacing:0em;}.cls-7{stroke:#262737;}.cls-11,.cls-7{stroke-width:5px;}.cls-9{letter-spacing:-0.01em;}.cls-10{stroke:#e6e6e6;}.cls-12{font-size:12px;fill:gray;}.cls-13{letter-spacing:-0.03em;}.cls-14{letter-spacing:-0.01em;}.cls-15{letter-spacing:-0.02em;}.cls-16{letter-spacing:0em;}.cls-17{letter-spacing:0em;}.cls-18{letter-spacing:0em;}</style>
     <marker
        inkscape:stockid="Arrow1Mstart"
        orient="auto"
@@ -133,7 +133,7 @@
          inkscape:connector-curvature="0"
          id="path4374-0"
          d="M 0,0 5,-5 -12.5,0 5,5 0,0 Z"
-         style="fill:#88c9d3;fill-opacity:1;fill-rule:evenodd;stroke:#88c9d3;stroke-width:1pt;stroke-opacity:1"
+         style="fill:#3c31d4;fill-opacity:1;fill-rule:evenodd;stroke:#3c31d4;stroke-width:1pt;stroke-opacity:1"
          transform="matrix(0.4,0,0,0.4,4,0)" />
     </marker>
     <clipPath
@@ -196,7 +196,7 @@
          inkscape:connector-curvature="0"
          id="path4374-0-0"
          d="M 0,0 5,-5 -12.5,0 5,5 0,0 Z"
-         style="fill:#00deb6;fill-opacity:1;fill-rule:evenodd;stroke:#00deb6;stroke-width:1pt;stroke-opacity:1"
+         style="fill:#3c31d4;fill-opacity:1;fill-rule:evenodd;stroke:#3c31d4;stroke-width:1pt;stroke-opacity:1"
          transform="matrix(0.4,0,0,0.4,4,0)" />
     </marker>
     <marker
@@ -210,7 +210,7 @@
       <path
          id="path4374-9"
          d="M 0,0 5,-5 -12.5,0 5,5 0,0 Z"
-         style="fill:#00deb6;fill-opacity:1;fill-rule:evenodd;stroke:#00deb6;stroke-width:1pt;stroke-opacity:1"
+         style="fill:#3c31d4;fill-opacity:1;fill-rule:evenodd;stroke:#3c31d4;stroke-width:1pt;stroke-opacity:1"
          transform="matrix(0.4,0,0,0.4,4,0)"
          inkscape:connector-curvature="0" />
     </marker>
@@ -226,7 +226,7 @@
          inkscape:connector-curvature="0"
          id="path4374-0-9"
          d="M 0,0 5,-5 -12.5,0 5,5 0,0 Z"
-         style="fill:#88c9d3;fill-opacity:1;fill-rule:evenodd;stroke:#88c9d3;stroke-width:1pt;stroke-opacity:1"
+         style="fill:#3c31d4;fill-opacity:1;fill-rule:evenodd;stroke:#3c31d4;stroke-width:1pt;stroke-opacity:1"
          transform="matrix(0.4,0,0,0.4,4,0)" />
     </marker>
     <marker
@@ -241,14 +241,14 @@
          inkscape:connector-curvature="0"
          id="path4374-0-9-9"
          d="M 0,0 5,-5 -12.5,0 5,5 0,0 Z"
-         style="fill:#88c9d3;fill-opacity:1;fill-rule:evenodd;stroke:#88c9d3;stroke-width:1pt;stroke-opacity:1"
+         style="fill:#3c31d4;fill-opacity:1;fill-rule:evenodd;stroke:#3c31d4;stroke-width:1pt;stroke-opacity:1"
          transform="matrix(0.4,0,0,0.4,4,0)" />
     </marker>
   </defs>
   <title
      id="title7">Artboard 1 copy</title>
   <rect
-     style="fill:#f7f7f7;fill-opacity:1;stroke:#88c9d3;stroke-width:1;stroke-linecap:round;stroke-linejoin:round;stroke-miterlimit:10;stroke-dasharray:none;stroke-opacity:1"
+     style="fill:#f7f7f7;fill-opacity:1;stroke:#3c31d4;stroke-width:1;stroke-linecap:round;stroke-linejoin:round;stroke-miterlimit:10;stroke-dasharray:none;stroke-opacity:1"
      id="rect11772"
      width="330"
      height="196"
@@ -257,7 +257,7 @@
   <circle
      class="cls-11"
      id="circle209-2-0-1"
-     style="fill:#ffffff;fill-opacity:1;stroke:#88c9d3;stroke-width:3.75;stroke-linecap:round;stroke-miterlimit:8.5;stroke-dasharray:none;stroke-opacity:1"
+     style="fill:#ffffff;fill-opacity:1;stroke:#3c31d4;stroke-width:3.75;stroke-linecap:round;stroke-miterlimit:8.5;stroke-dasharray:none;stroke-opacity:1"
      inkscape:transform-center-x="-7.2470959"
      inkscape:transform-center-y="99.482843"
      cx="61.94891"
@@ -266,7 +266,7 @@
   <path
      class="cls-11"
      id="circle209-7-4"
-     style="fill:none;stroke:#88c9d3;stroke-width:3.75;stroke-linecap:round;stroke-miterlimit:8.5;stroke-dasharray:none;stroke-opacity:1"
+     style="fill:none;stroke:#3c31d4;stroke-width:3.75;stroke-linecap:round;stroke-miterlimit:8.5;stroke-dasharray:none;stroke-opacity:1"
      inkscape:transform-center-x="-5.4824618"
      inkscape:transform-center-y="75.259237"
      sodipodi:type="arc"
@@ -283,7 +283,7 @@
      d="M 347.06781,56.625781 Z"
      id="path11-6"
      inkscape:connector-curvature="0"
-     style="fill:#00deb6" />
+     style="fill:#3c31d4" />
   <path
      d="m 347.06781,56.625781 0,0 m 0,0 0,0 m 0,0 z m 0,0 z"
      id="path27-3"
@@ -411,43 +411,43 @@
      d="m 347.06781,56.625781 0,0"
      id="path79-9"
      inkscape:connector-curvature="0"
-     style="fill:none;stroke:#00deb6;stroke-width:5px;stroke-miterlimit:10" />
+     style="fill:none;stroke:#3c31d4;stroke-width:5px;stroke-miterlimit:10" />
   <path
      class="cls-11"
      d="m 347.06781,56.625781 0,0"
      id="path85-7"
      inkscape:connector-curvature="0"
-     style="fill:none;stroke:#00deb6;stroke-width:5px;stroke-miterlimit:10" />
+     style="fill:none;stroke:#3c31d4;stroke-width:5px;stroke-miterlimit:10" />
   <path
      class="cls-11"
      d="m 347.06781,56.625781 0,0"
      id="path87-8"
      inkscape:connector-curvature="0"
-     style="fill:none;stroke:#00deb6;stroke-width:5px;stroke-miterlimit:10" />
+     style="fill:none;stroke:#3c31d4;stroke-width:5px;stroke-miterlimit:10" />
   <path
      class="cls-11"
      d="m 347.06781,56.625781 0,0"
      id="path89-3"
      inkscape:connector-curvature="0"
-     style="fill:none;stroke:#00deb6;stroke-width:5px;stroke-miterlimit:10" />
+     style="fill:none;stroke:#3c31d4;stroke-width:5px;stroke-miterlimit:10" />
   <path
      class="cls-11"
      d="m 347.06781,56.625781 0,0"
      id="path91-9"
      inkscape:connector-curvature="0"
-     style="fill:none;stroke:#00deb6;stroke-width:5px;stroke-miterlimit:10" />
+     style="fill:none;stroke:#3c31d4;stroke-width:5px;stroke-miterlimit:10" />
   <path
      class="cls-11"
      d="m 347.06781,56.625781 0,0"
      id="path93-7"
      inkscape:connector-curvature="0"
-     style="fill:none;stroke:#00deb6;stroke-width:5px;stroke-miterlimit:10" />
+     style="fill:none;stroke:#3c31d4;stroke-width:5px;stroke-miterlimit:10" />
   <path
      class="cls-11"
      d="m 347.06781,56.625781 0,0"
      id="path95-2"
      inkscape:connector-curvature="0"
-     style="fill:none;stroke:#00deb6;stroke-width:5px;stroke-miterlimit:10" />
+     style="fill:none;stroke:#3c31d4;stroke-width:5px;stroke-miterlimit:10" />
   <path
      class="cls-10"
      d="m 347.06781,56.625781 0,0"
@@ -525,13 +525,13 @@
      d="M 347.06781,56.625781 Z"
      id="path171-1"
      inkscape:connector-curvature="0"
-     style="fill:#00deb6" />
+     style="fill:#3c31d4" />
   <path
      class="cls-2"
      d="M 347.06781,56.625781 Z"
      id="path197-3"
      inkscape:connector-curvature="0"
-     style="fill:#00deb6" />
+     style="fill:#3c31d4" />
   <path
      class="cls-8"
      d="M 347.06781,56.625781 Z"
@@ -549,14 +549,14 @@
   <circle
      class="cls-11"
      id="circle209-2-0-1-7"
-     style="fill:#ffffff;fill-opacity:1;stroke:#88c9d3;stroke-width:3.75;stroke-linecap:round;stroke-miterlimit:8.5;stroke-dasharray:none;stroke-opacity:1"
+     style="fill:#ffffff;fill-opacity:1;stroke:#3c31d4;stroke-width:3.75;stroke-linecap:round;stroke-miterlimit:8.5;stroke-dasharray:none;stroke-opacity:1"
      inkscape:transform-center-x="-7.2470929"
      inkscape:transform-center-y="99.48285"
      cx="61.927174"
      cy="61.927174"
      r="30.052174" />
   <path
-     style="fill:none;fill-rule:evenodd;stroke:#88c9d3;stroke-width:3.75;stroke-linecap:butt;stroke-linejoin:miter;stroke-miterlimit:8.5;stroke-dasharray:none;stroke-opacity:1"
+     style="fill:none;fill-rule:evenodd;stroke:#3c31d4;stroke-width:3.75;stroke-linecap:butt;stroke-linejoin:miter;stroke-miterlimit:8.5;stroke-dasharray:none;stroke-opacity:1"
      d="m 61.927177,91.979345 1.2e-5,85.867835 0.02338,54.41999"
      id="path12354-2-8-1"
      inkscape:connector-curvature="0"
@@ -566,7 +566,7 @@
      d="m 61.979444,54.291698 a 2.623283,2.623283 0 1 1 -2.632208,2.614359 2.6226454,2.6226454 0 0 1 2.632208,-2.614359 m -0.03634,11.242367 c 3.70985,0.01216 7.61352,1.849181 7.61097,2.64816 l -0.005,1.374128 -15.239787,-0.04976 0.0046,-1.374136 c 0,-0.798968 3.918343,-2.610528 7.628814,-2.598408 m 0.044,-13.615696 a 4.9966081,4.9966081 0 1 0 4.980663,5.012544 4.9953329,4.9953329 0 0 0 -4.980663,-5.012544 z m -0.03633,11.242366 c -3.335352,-0.01088 -9.998772,1.641302 -10.010892,4.96409 l -0.01214,3.747448 19.986445,0.06376 0.0127,-3.747456 c 0.0114,-3.321504 -6.6411,-5.017013 -9.976008,-5.027852 z"
      inkscape:connector-curvature="0" />
   <rect
-     style="fill:#ffffff;fill-opacity:1;stroke:#88c9d3;stroke-width:0.96977818;stroke-linecap:round;stroke-linejoin:round;stroke-miterlimit:10;stroke-dasharray:none;stroke-opacity:1"
+     style="fill:#ffffff;fill-opacity:1;stroke:#3c31d4;stroke-width:0.96977818;stroke-linecap:round;stroke-linejoin:round;stroke-miterlimit:10;stroke-dasharray:none;stroke-opacity:1"
      id="rect11772-8"
      width="247.8239"
      height="95.198715"
@@ -649,7 +649,7 @@
        style="font-style:normal;font-variant:normal;font-weight:bold;font-stretch:normal;font-size:13.75px;line-height:125%;font-family:Roboto;-inkscape-font-specification:'Roboto, Bold';text-align:start;writing-mode:lr-tb;text-anchor:start;fill:#1f1f1f;fill-opacity:1">interests</tspan>
   </text>
   <path
-     style="fill:none;fill-rule:evenodd;stroke:#88c9d3;stroke-width:1;stroke-linecap:butt;stroke-linejoin:miter;stroke-miterlimit:4;stroke-dasharray:1, 1;stroke-dashoffset:0;stroke-opacity:1"
+     style="fill:none;fill-rule:evenodd;stroke:#3c31d4;stroke-width:1;stroke-linecap:butt;stroke-linejoin:miter;stroke-miterlimit:4;stroke-dasharray:1, 1;stroke-dashoffset:0;stroke-opacity:1"
      d="m 115.05005,118.83972 247.794,0"
      id="path9962"
      inkscape:connector-curvature="0" />

--- a/docs/conf.py
+++ b/docs/conf.py
@@ -24,6 +24,8 @@ from recommonmark.parser import CommonMarkParser
 
 # -- General configuration ------------------------------------------------
 
+html_context = {'bods_schema_version': '0.1'}
+
 # If your documentation needs a minimal Sphinx version, state it here.
 #
 # needs_sphinx = '1.0'
@@ -197,7 +199,7 @@ class JSONValue(LiteralInclude):
         except KeyError as e:
             title = filename
         pointed = resolve_pointer(json_obj, self.options['pointer'])
-     
+
         string = json.dumps(pointed, indent='    ')
         if string.startswith('"') and string.endswith('"'):
             string = string[1:-1]

--- a/requirements.in
+++ b/requirements.in
@@ -5,4 +5,4 @@ sphinx_rtd_theme
 -e git+https://github.com/rtfd/recommonmark.git@450909bdcf4c5eafde7c89696006530ba7cc78de#egg=recommonmark
 -e git+https://github.com/OpenDataServices/sphinxcontrib-jsonschema.git@8d0d2bb00742b25707866b0f7a2b6c0c35948c5e#egg=sphinxcontrib-jsonschema
 -e git+https://github.com/OpenDataServices/sphinxcontrib-opendataservices.git@fab0ff0167d32ec243d42f272e0e50766299c078#egg=sphinxcontrib-opendataservices
--e git+https://github.com/openownership/data-standard-sphinx-theme.git@d5bbf2b4f2e67866918ed8194b57b5f7bebbafae#egg=standard_theme
+-e git+https://github.com/openownership/data-standard-sphinx-theme.git@3611c856a18381dbbbc172f5859646bb9927c038#egg=standard_theme

--- a/requirements.txt
+++ b/requirements.txt
@@ -4,7 +4,7 @@ sphinx-rtd-theme==0.3.1
 -e git+https://github.com/rtfd/recommonmark.git@450909bdcf4c5eafde7c89696006530ba7cc78de#egg=recommonmark
 -e git+https://github.com/OpenDataServices/sphinxcontrib-jsonschema.git@8d0d2bb00742b25707866b0f7a2b6c0c35948c5e#egg=sphinxcontrib_jsonschema
 -e git+https://github.com/OpenDataServices/sphinxcontrib-opendataservices.git@fab0ff0167d32ec243d42f272e0e50766299c078#egg=sphinxcontrib_opendataservices
--e git+https://github.com/openownership/data-standard-sphinx-theme.git@d5bbf2b4f2e67866918ed8194b57b5f7bebbafae#egg=standard_theme
+-e git+https://github.com/openownership/data-standard-sphinx-theme.git@3611c856a18381dbbbc172f5859646bb9927c038#egg=standard_theme
 ## The following requirements were added by pip freeze:
 alabaster==0.7.10
 Babel==2.6.0


### PR DESCRIPTION
Counterpart to #302, to put the new theme into v0-1.

Here I haven't been able to directly cherry-pick @Lathrisk's work, so I've made commits approximating them:
- Updating the theme commit hash (which is pinned to a specific commit in both `requirements.in` and `requirements.txt` in `v0-1`)
- Updating all the SVG diagrams (which are older versions pre-translation work and we don't have language specific built versions)

I've also made a small change to `docs/conf.py` (The ReadTheDocs config file) to backport https://github.com/openownership/data-standard/commit/980ec78787e50dfec756e0d91931faa371c1b47e (adding a variable for the version number so we can display it in the sidebar).

Note that this currently removes the "old version" banner added by https://github.com/openownership/data-standard-sphinx-theme/commit/d5bbf2b4f2e67866918ed8194b57b5f7bebbafae. I don't think keeping separate theme branches for each old version is very sustainable (and I note we don't do it for the three v0-0-x branches already) so I'm going to explore tackling https://github.com/openownership/bods-dev-handbook/issues/13 in the first instance to replace this.