### PR TITLE
Fix v0-1 builds

### DIFF
--- a/readthedocs.yml
+++ b/readthedocs.yml
@@ -4,7 +4,7 @@ formats:
 requirements_file: requirements.txt
 
 build:
-    image: 2.0
+    image: latest
 
 python:
    version: 3.5


### PR DESCRIPTION
This is needed similar to https://github.com/openownership/data-standard/pull/292 to be able to build the v0-1 branch.