### PR TITLE
Update theme to latest commit for OO logo changes [master]

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -5,7 +5,7 @@ CommonMark==0.7.5
 -e git+https://github.com/rtfd/recommonmark.git@450909bdcf4c5eafde7c89696006530ba7cc78de#egg=recommonmark
 -e git+https://github.com/OpenDataServices/sphinxcontrib-jsonschema.git@8a3982bf7701420e50d69f2341213ced2b18ca54#egg=sphinxcontrib_jsonschema
 -e git+https://github.com/OpenDataServices/sphinxcontrib-opendataservices.git@fab0ff0167d32ec243d42f272e0e50766299c078#egg=sphinxcontrib_opendataservices
--e git+https://github.com/openownership/data-standard-sphinx-theme.git@3611c856a18381dbbbc172f5859646bb9927c038#egg=standard_theme
+-e git+https://github.com/openownership/data-standard-sphinx-theme.git@8b05124bd0c5aae102a0f60f892d4d9fb83e9b4b#egg=standard_theme
 ocds-babel==0.2.1
 urllib3==1.25.8
 requests==2.23.0


### PR DESCRIPTION
Open Ownership has slightly changed their logo, I've [updated the theme](https://github.com/openownership/data-standard-sphinx-theme/commit/8b05124bd0c5aae102a0f60f892d4d9fb83e9b4b) to use it. This PR updates the master branch, I'll make matching PRs for versions 0.2.0 and 0.1.0 in a moment.