### PR TITLE
Typo corrected, 'state date' > 'start date'

### DIFF
--- a/schema/components.json
+++ b/schema/components.json
@@ -313,7 +313,7 @@
           }
         },
         "startDate": {
-          "title": "State date",
+          "title": "Start date",
           "description": "When did this interest first occur. Please provide as precise a date as possible in ISO 8601 format. When only the year or year and month is known, these can be given as YYYY or YYYY-MM.",
           "type": "string",
           "pattern": "^([\\+-]?\\d{4}(?!\\d{2}\b))((-?)((0[1-9]|1[0-2])(\\3([12]\\d|0[1-9]|3[01]))?|W([0-4]\\d|5[0-2])(-?[1-7])?|(00[1-9]|0[1-9]\\d|[12]\\d{2}|3([0-5]\\d|6[1-6])))([T\\s]((([01]\\d|2[0-3])((:?)[0-5]\\d)?|24\\:?00)([\\.,]\\d+(?!:))?)?(\\17[0-5]\\d([\\.,]\\d+)?)?([zZ]|([\\+-])([01]\\d|2[0-3]):?([0-5]\\d)?)?)?)?$"


### PR DESCRIPTION
Quicker to fix this than to report and fix later. So a quick PR here.