### PR TITLE
345 move pepstatus

### DIFF
--- a/docs/schema/changelog.rst
+++ b/docs/schema/changelog.rst
@@ -18,6 +18,7 @@ ChangeLog
 Changed
 -------
 - The ``interestType`` and ``unspecifiedReason`` codelist codes have been changed from using hyphens to camelCase.
+- ``hasPepStatus`` and ``pepDetails`` are replaced with ``politicalExposure`` object  that contains ``status`` and ``details`` properties.
 
 
 [0.2] - 2019-06-30

--- a/examples/4a-simple-pep-declaration.json
+++ b/examples/4a-simple-pep-declaration.json
@@ -30,7 +30,9 @@
         "fullName": "Michael Hubbard"
       }
     ],
-    "hasPepStatus": true,
+    "politicalExposure": {
+      "status": "isPep"
+    },
     "publicationDetails": {
       "publicationDate": "2019-06-07",
       "bodsVersion": "0.2",

--- a/examples/4b-full-pep-declaration.json
+++ b/examples/4b-full-pep-declaration.json
@@ -32,26 +32,28 @@
         "fullName": "Michael Hubbard"
       }
     ],
-    "hasPepStatus": true,
-    "pepStatusDetails": [
-      {
-        "jurisdiction": {
-          "code": "gb"
-        },
-        "reason": "Member of Parliament",
-        "startDate": "2017-10-15",
-        "source": {
-          "type": [
-            "selfDeclaration"
-          ],
-          "assertedBy": [
-            {
-              "name": "Michael Hubbard"
-            }
-          ]
+    "politicalExposure": {
+      "status": "isPep",
+      "details": [
+        {
+          "jurisdiction": {
+            "code": "gb"
+          },
+          "reason": "Member of Parliament",
+          "startDate": "2017-10-15",
+          "source": {
+            "type": [
+              "selfDeclaration"
+            ],
+            "assertedBy": [
+              {
+                "name": "Michael Hubbard"
+              }
+            ]
+          }
         }
-      }
-    ],
+      ]
+    },
     "publicationDetails": {
       "publicationDate": "2019-06-07",
       "bodsVersion": "0.2",

--- a/schema/components.json
+++ b/schema/components.json
@@ -474,7 +474,7 @@
         },
         "missingInfoReason": {
           "title": "Missing information reason(s)",
-          "description": "For disclosure regimes where a PEP declarations is required but not provided, this field should contain an explanation of the reason that PEP status for the person is not provided. This may be a standard descriptive phrase from the source system, or a free-text justification. This field should only be filled out where hasPepStatus is missing. Where this field is present it should be the only field except for `source`.",
+          "description": "An explanation of the reason that PEP status for the person is not provided (i.e. `politicalExposure.status` is 'unknown'). This may be a standard descriptive phrase from the source system, or a free-text justification. Where this field is present it should be the only field except for `source`.",
           "type": "string"
         },
         "jurisdiction": {

--- a/schema/person-statement.json
+++ b/schema/person-statement.json
@@ -144,21 +144,6 @@
       },
       "propertyOrder": 60
     },
-    "hasPepStatus": {
-      "title": "Politically Exposed Person Status",
-      "description": "Is the person described in this statement a politically exposed person? This field should not be used if PEP declarations are not expected as part of this disclosure. If a PEP declaration is expected but missing this field should not be used but the reason for the missing data declared in the pepStatusDetails field.",
-      "type": "boolean",
-      "propertyOrder": 79
-    },
-    "pepStatusDetails": {
-      "title": "Politically Exposed Person Status Details",
-      "description": "One or more descriptions of this person's Politically-Exposed Person (PEP) status.",
-      "type": "array",
-      "items": {
-        "$ref": "components.json#/definitions/PepStatusDetails"
-      },
-      "propertyOrder": 80
-    },
     "publicationDetails": {
       "title": "Publication details",
       "description": "Information concerning the original publication of this statement.",
@@ -182,6 +167,33 @@
     },
     "replacesStatements": {
       "$ref": "components.json#/definitions/ReplacesStatements"
+    },
+    "politicalExposure": {
+      "type": "object",
+      "title": "Political Exposure",
+      "description": "Information about whether, and how, the person described by this statement is politically exposed. Use this property only if politically exposed person (PEP) declarations are expected as part of beneficial ownership declarations.",
+      "required": [
+        "status"
+      ],
+      "properties": {
+        "status": {
+          "type": "string",
+          "description": "This value is 'isPep' or 'isNotPep' according to whether the person described by this statement has the status of politically exposed person (PEP). An 'unknown' value means a PEP status declaration is expected but missing; the reason for the missing data SHOULD be supplied in the details array.",
+          "enum": [
+            "isPep",
+            "isNotPep",
+            "unknown"
+          ]
+        },
+        "details": {
+          "type": "array",
+          "title": "Politically Exposed Person Details",
+          "description": "One or more descriptions of this person's Politically Exposed Person (PEP) status.",
+          "items": {
+            "$ref": "components.json#/definitions/PepStatusDetails"
+          }
+        }
+      }
     }
   },
   "required": [


### PR DESCRIPTION
# Overview
Schema:  Move hasPepStatus into object.

https://github.com/openownership/data-standard/issues/345

## Translations

- [ ] I've notified the translation coordinator of any new strings that will need
      translating. See: https://openownership.github.io/bods-dev-handbook/translations.html

## Documentation & Release

- [ ] I've thought about how and when this needs to be released. See:
      https://openownership.github.io/bods-dev-handbook/standard_releases.html      
- [ ] I've updated the changelog, if necessary.
- [ ] I've added or edited any related documentation. See: https://github.com/openownership/bods-dev-handbook/blob/master/style_guide.md
