### PR TITLE
Add Feature template to issue templates

### DIFF
--- a/.github/ISSUE_TEMPLATE/feature-development-ticket.md
+++ b/.github/ISSUE_TEMPLATE/feature-development-ticket.md
@@ -1,7 +1,6 @@
 ---
 name: Feature development ticket
-about: This ticket helps track progress towards developing a particular feature in
-  the Beneficial Ownership Data Standard (BODS) where changes or revisions to the standard may be required.
+about: This ticket helps track progress towards developing a particular feature in the Beneficial Ownership Data Standard (BODS) where changes or revisions to the standard may be required.
 title: 'Feature: [feature name]'
 labels: ''
 assignees: ''

--- a/.github/ISSUE_TEMPLATE/feature-development-ticket.md
+++ b/.github/ISSUE_TEMPLATE/feature-development-ticket.md
@@ -1,24 +1,24 @@
 ---
 name: Feature development ticket
 about: This ticket helps track progress towards developing a particular feature in
-  BODS to address a deficit in the standard.
+  the Beneficial Ownership Data Standard (BODS) where changes or revisions to the standard may be required.
 title: 'Feature: [feature name]'
 labels: ''
 assignees: ''
 
 ---
 
-_[This ticket helps track progress towards developing a particular feature in BODS to address a deficit in the standard. It should be placed on the [BODS Feature Tracker](https://github.com/openownership/data-standard/projects/4), under the relevant status column._
+_[This ticket helps track progress towards developing a particular feature in BODS where changes or revisions to the standard may be required. It should be placed on the [BODS Feature Tracker](https://github.com/openownership/data-standard/projects/4), under the relevant status column._
 
 _See [Feature development in BODS](https://openownership.github.io/bods-dev-handbook/feature_development.html) in the Handbook._
 
 _The title of this GitHub ticket should be 'Feature: XXXXX' where XXXXX is the feature name below. The information in this first post on the thread should be updated as necessary so that it holds up-to-date information. Comments on this ticket can be used to help track high-level work towards this feature or to refine this set of information.]_
 
-Feature name: **XXXXX**
+## Feature name: **XXXXX**
 
 ### Feature background
 
-**What needs are met by introducing or developing this feature in BODS?** _[Summarise these needs. Link to user stories, reports, blogs and other evidence where possible. Or add user stories here directly.]_
+**What user needs are met by introducing or developing this feature in BODS?** _[Summarise these needs. Link to user stories, reports, blogs and other evidence where possible. Or add user stories here directly.]_
 
 
 **What impact would not meeting these needs have?**
@@ -30,9 +30,7 @@ Feature name: **XXXXX**
 **How urgent is it to meet the above needs?**
 
 
-
 **Are there any obvious problems, dependencies or challenges that any proposal to develop this feature would need to address?**
-
 
 
 ### Feature work tracking

--- a/.github/ISSUE_TEMPLATE/feature-development-ticket.md
+++ b/.github/ISSUE_TEMPLATE/feature-development-ticket.md
@@ -1,0 +1,40 @@
+---
+name: Feature development ticket
+about: This ticket helps track progress towards developing a particular feature in
+  BODS to address a deficit in the standard.
+title: 'Feature: [feature name]'
+labels: ''
+assignees: ''
+
+---
+
+_[This ticket helps track progress towards developing a particular feature in BODS to address a deficit in the standard. It should be placed on the [BODS Feature Tracker](https://github.com/openownership/data-standard/projects/4), under the relevant status column._
+
+_See [Feature development in BODS](https://openownership.github.io/bods-dev-handbook/feature_development.html) in the Handbook._
+
+_The title of this GitHub ticket should be 'Feature: XXXXX' where XXXXX is the feature name below. The information in this first post on the thread should be updated as necessary so that it holds up-to-date information. Comments on this ticket can be used to help track high-level work towards this feature or to refine this set of information.]_
+
+Feature name: **XXXXX**
+
+### Feature background
+
+**What needs are met by introducing or developing this feature in BODS?** _[Summarise these needs. Link to user stories, reports, blogs and other evidence where possible. Or add user stories here directly.]_
+
+
+**What impact would not meeting these needs have?**
+
+
+**How important is it to meet the above needs?**
+
+
+**How urgent is it to meet the above needs?**
+
+
+
+**Are there any obvious problems, dependencies or challenges that any proposal to develop this feature would need to address?**
+
+
+
+### Feature work tracking
+
+_[Link to proposals, bugs and issues in the repository to help track work on this feature]_


### PR DESCRIPTION
This is a new issue template based on that used for these feature tickets:

SOEs: https://github.com/openownership/data-standard/issues/360
PLCs: https://github.com/openownership/data-standard/issues/359

