### PR TITLE
docs: update links to use https

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,13 +1,13 @@
 Beneficial Ownership Data Standard (BODS)
 ========================================
 
-[![Documentation Status](https://readthedocs.org/projects/beneficial-ownership-data-standard/badge/?version=latest)](http://standard.openownership.org/en/latest/?badge=latest)
+[![Documentation Status](https://readthedocs.org/projects/beneficial-ownership-data-standard/badge/?version=latest)](https://standard.openownership.org/en/latest/?badge=latest)
 
 The Beneficial Ownership Data Standard provides a specification for modelling and publishing information on the beneficial ownership and control of companies. 
 
-It has been created by [OpenOwnership](http://www.openownership.org), and is provided under an open license for re-use. 
+It has been created by [OpenOwnership](https://www.openownership.org), and is provided under an open license for re-use. 
 
-You can find the latest version of the schema and documentation for review at [http://standard.openownership.org/](http://standard.openownership.org/)
+You can find the latest version of the schema and documentation for review at [https://standard.openownership.org/](https://standard.openownership.org/)
 
 We welcome feedback on the standard through this project's issue tracker.
 

--- a/docs/about/credits.rst
+++ b/docs/about/credits.rst
@@ -3,22 +3,22 @@ Credits
 
 The first beta version of the Beneficial Ownership Data Standard was
 written by Tim Davies (`Open Data Services
-Co-operative <http://www.opendataservices.coop>`_) with Ben Symonds
-(`OpenCorporates <http://www.opencorporates.com>`_), Chris Taggart
-(`OpenCorporates <http://www.opencorporates.com>`_) and Jack Lord
-(`Open Data Services Co-operative <http://www.opendataservices.coop>`_)
+Co-operative <https://www.opendataservices.coop>`_) with Ben Symonds
+(`OpenCorporates <https://www.opencorporates.com>`_), Chris Taggart
+(`OpenCorporates <https://www.opencorporates.com>`_) and Jack Lord
+(`Open Data Services Co-operative <https://www.opendataservices.coop>`_)
 and supported by the :doc:`data standard working group <governance>`.
 
 The 0.1 version was written by Tim Davies and Jack Lord with supporting
 documentation from Kadie Armstrong (`Open Data Services
-Co-operative <http://www.opendataservices.coop>`_), technical work from
+Co-operative <https://www.opendataservices.coop>`_), technical work from
 James Baster (`Open Data Services
-Co-operative <http://www.opendataservices.coop>`_) and input from the
+Co-operative <https://www.opendataservices.coop>`_) and input from the
 :doc:`data standard working group <governance>`.
 
 The 0.2 version was written by Jack Lord, Simon Whitehouse and Kadie
 Armstrong (`Open Data Services
-Co-operative <http://www.opendataservices.coop>`_), technical work from
+Co-operative <https://www.opendataservices.coop>`_), technical work from
 James Baster, Ben Webb, Amy Guy and David Raznick (`Open Data Services
-Co-operative <http://www.opendataservices.coop>`_) and input from the
+Co-operative <https://www.opendataservices.coop>`_) and input from the
 :doc:`data standard working group <governance>`.

--- a/docs/about/governance.rst
+++ b/docs/about/governance.rst
@@ -5,7 +5,7 @@ Governance
 Data Standard Working Group - abbreviated Terms of Reference (2016)
 -------------------------------------------------------------------
 
-The Beneficial Ownership Data Standard Working Group (DSWG) will drive the initial creation of a free and open data standard for Beneficial Ownership designed to reduce the technical barriers to the collection and re-use of beneficial ownership data, including (but not limited to) by `the OpenOwnership Register <http://openownership.org/>`_ being created by civil society around the world.  OpenOwnership is also `creating private sector, public sector and civil society working groups <http://openownership.org/get-involved/>`_.
+The Beneficial Ownership Data Standard Working Group (DSWG) will drive the initial creation of a free and open data standard for Beneficial Ownership designed to reduce the technical barriers to the collection and re-use of beneficial ownership data, including (but not limited to) by `the OpenOwnership Register <https://openownership.org/>`_ being created by civil society around the world.  OpenOwnership is also `creating private sector, public sector and civil society working groups <https://openownership.org/get-involved/>`_.
 
 This working group will include stakeholders from a range of backgrounds with an interest and expertise in data relating to corporate control or beneficial ownership, and to the use of such data in the public interest. While the development of the standard will take place through an open process, to which anyone can contribute, working group members take on a special responsibility for guiding development of the standard, and ensuring that relevant requirements, user needs and technical considerations are taken into account. 
 

--- a/docs/about/index.rst
+++ b/docs/about/index.rst
@@ -66,12 +66,12 @@ the world's leading transparency organizations including `Transparency
 International <https://www.transparency.org/>`__,
 `OpenCorporates <https://opencorporates.com>`__,
 `One <https://www.one.org/international/>`__, the `Open Contracting
-Partnership <http://www.open-contracting.org>`__, `Global
+Partnership <https://www.open-contracting.org>`__, `Global
 Witness <https://www.globalwitness.org/en-gb/>`__ and `The B
 Team <http://bteam.org/>`__.
 
 The specification and documentation have been developed by `Open Data
-Services Co-operative <http://www.opendataservices.coop>`__ and
+Services Co-operative <https://www.opendataservices.coop>`__ and
 `OpenCorporates <https://opencorporates.com>`__. Read the
 :doc:`credits <credits>` for full details of the Standard's developers.
 

--- a/docs/schema/schema-browser.rst
+++ b/docs/schema/schema-browser.rst
@@ -10,7 +10,7 @@ Schema browser
     **MUST** and **SHOULD** are used in the schema to denote required and recommended elements of the Standard, as defined in `RFC2119 <https://tools.ietf.org/html/rfc2119>`_.
 
 
-The draft Beneficial Ownership Data Standard schema is defined using `JSON Schema 0.4 <http://json-schema.org/>`_.
+The draft Beneficial Ownership Data Standard schema is defined using `JSON Schema 0.4 <https://json-schema.org/>`_.
 
 The structure of each of the schema's top level components can be explored using the viewers below. (Click on sub-components to reveal their properties.)
 


### PR DESCRIPTION
Links to opendataservices.coop and openownership.org are https, fixes #367 