### PR TITLE
schema: Fix required properties of Annotation, for #333

### DIFF
--- a/docs/schema/changelog.rst
+++ b/docs/schema/changelog.rst
@@ -12,6 +12,12 @@ ChangeLog
 
     The schema specifies a **structure**, **fields** and **codelists** but does not yet enforce validation constraints on most fields. 
 
+[Unreleased] - 2021-10-21
+
+Changed
+-------
+- Required fields `statementPointerTarget` and `motivation` are moved from inside the `anyOf` statement to the top level, as they apply to all motivation types.
+
 [Unreleased] - 2021-03-30
 =========================
 

--- a/docs/schema/changelog.rst
+++ b/docs/schema/changelog.rst
@@ -12,14 +12,8 @@ ChangeLog
 
     The schema specifies a **structure**, **fields** and **codelists** but does not yet enforce validation constraints on most fields. 
 
-[Unreleased] - 2021-10-21
-
-Changed
--------
-- Required fields `statementPointerTarget` and `motivation` are moved from inside the `anyOf` statement to the top level, as they apply to all motivation types.
-
-[Unreleased] - 2021-03-30
-=========================
+[Unreleased]
+============
 
 Added
 -----
@@ -29,6 +23,7 @@ Changed
 -------
 - The ``interestType`` and ``unspecifiedReason`` codelist codes have been changed from using hyphens to camelCase.
 - ``hasPepStatus`` and ``pepDetails`` are replaced with ``politicalExposure`` object  that contains ``status`` and ``details`` properties.
+- Required fields `statementPointerTarget` and `motivation` are moved from inside the `anyOf` statement to the top level, as they apply to all motivation types.
 
 
 [0.2] - 2019-06-30

--- a/schema/components.json
+++ b/schema/components.json
@@ -386,11 +386,15 @@
         },
         "url": {
           "title": "URL",
-          "description": "A linked resource that annotates, provides context for or enhances this statement. The content of the resource, or the relationship to the statement, MAY be described in the `description` field.",
+          "description": "A linked resource that annotates, provides context for or enhances this statement. The content of the resource, or the relationship to the statement, MAY be described in the `description` field. This field is REQUIRED if the value of `motivation` is 'linking'.",
           "type": "string",
           "format": "uri"
         }
       },
+      "required": [
+        "statementPointerTarget",
+        "motivation"
+      ],
       "anyOf": [
         {
           "properties": {
@@ -416,11 +420,7 @@
                 "transformation"
               ]
             }
-          },
-          "required": [
-            "statementPointerTarget",
-            "motivation"
-          ]
+          }
         }
       ]
     },


### PR DESCRIPTION
I moved the `require` on Annotation to the top level instead of being in the `anyOf` since `statementPointerTarget` and `motivation` are always required. This means they show up as required in the docs. The valid and invalid annotations tests still pass, so I don't think this affects the schema logic.

I've edited the description for `url` as this is conditional on the `motivation` value so there's nothing to do to the schema logic for that.