### PR TITLE
schema: Annotations to oneOf and add oneOfEnumSelectorField

### DIFF
--- a/docs/schema/changelog.rst
+++ b/docs/schema/changelog.rst
@@ -21,6 +21,7 @@ Added
 - ``Country.name`` is now a required field (previously it was defined as "MUST" in the description).
 - ``Jurisdiction.name`` is now a required field (previously it was defined as "MUST" in the description).
 - ``SecuritiesListing.stockExchangeJurisdiction`` has minimum and maximum lengths to match the two lists that values could be from.
+- Annotations have ``oneOfEnumSelectorField`` added to provide hints to validation code which will produce better error messages.
 
 Changed
 -------
@@ -31,6 +32,7 @@ Changed
 - Clarified ``Country.code`` is from the ISO 3166-1 list (previously it was unclear which ISO list was meant and used "digit" when it meant "letter").
 - Clarified ``Jurisdiction.code`` is from the ISO 3166-1 or ISO 3166-2 list (previously it was unclear which ISO list was meant and used "digit" when it meant "letter").
 - Clarified ``SecuritiesListing.stockExchangeJurisdiction`` is from the ISO 3166-1 or ISO 3166-2 list (previously it was unclear which ISO list was meant and used "digit" when it meant "letter").
+- Annotations changes from a ``anyOf`` to a ``oneOf``. This is technically correct and also is needed to improve validation messages.
 
 
 [0.2] - 2019-06-30

--- a/schema/components.json
+++ b/schema/components.json
@@ -395,7 +395,8 @@
         "statementPointerTarget",
         "motivation"
       ],
-      "anyOf": [
+      "oneOfEnumSelectorField": "motivation",
+      "oneOf": [
         {
           "properties": {
             "motivation": {

--- a/tests/bods_validate.py
+++ b/tests/bods_validate.py
@@ -39,6 +39,17 @@ def build_schemas_for_testing():
             )
             with open(os.path.join(absolute_path_to_schema_dir, source_file), "w") as fp:
                 created_json = json.loads(ctjs.get_as_string())
+                # The items in the annotations objects must not have additionalProperties set
+                # They factor out common elements of the oneOf bits as allowed in
+                #   https://json-schema.org/understanding-json-schema/reference/combining.html#factoring-schemas
+                # But additionalProperties is applied to the oneOf schema only, not the full item and that causes issues
+                if source_file.endswith('entity-statement.json') or source_file.endswith('ownership-or-control-statement.json') or source_file.endswith('person-statement.json'):
+                    for j in range(0, 2):
+                        created_json['properties']['annotations']['items']['oneOf'][j]['additionalProperties'] = True
+                if source_file.endswith('bods-package.json'):
+                    for i in range(0, 3):
+                        for j in range(0, 2):
+                            created_json['items']['oneOf'][i]['properties']['annotations']['items']['oneOf'][j]['additionalProperties'] = True
                 # write with correct indentation
                 fp.write(json.dumps(created_json, ensure_ascii=False, indent=2, separators=(',', ': ')) + '\n')
 

--- a/tests/schema/meta-schema.json
+++ b/tests/schema/meta-schema.json
@@ -1,0 +1,267 @@
+{
+  "id": "http://json-schema.org/draft-04/schema#",
+  "$schema": "http://json-schema.org/draft-04/schema#",
+  "description": "Core schema meta-schema",
+  "definitions": {
+    "schemaArray": {
+      "type": "array",
+      "minItems": 1,
+      "items": {
+        "$ref": "#"
+      }
+    },
+    "positiveInteger": {
+      "type": "integer",
+      "minimum": 0
+    },
+    "positiveIntegerDefault0": {
+      "allOf": [
+        {
+          "$ref": "#/definitions/positiveInteger"
+        },
+        {
+          "default": 0
+        }
+      ]
+    },
+    "simpleTypes": {
+      "enum": [
+        "array",
+        "boolean",
+        "integer",
+        "null",
+        "number",
+        "object",
+        "string"
+      ]
+    },
+    "stringArray": {
+      "type": "array",
+      "items": {
+        "type": "string"
+      },
+      "minItems": 1,
+      "uniqueItems": true
+    }
+  },
+  "type": "object",
+  "properties": {
+    "id": {
+      "type": "string"
+    },
+    "$schema": {
+      "type": "string"
+    },
+    "title": {
+      "type": "string"
+    },
+    "description": {
+      "type": "string"
+    },
+    "default": {},
+    "multipleOf": {
+      "type": "number",
+      "minimum": 0,
+      "exclusiveMinimum": true
+    },
+    "maximum": {
+      "type": "number"
+    },
+    "exclusiveMaximum": {
+      "type": "boolean",
+      "default": false
+    },
+    "minimum": {
+      "type": "number"
+    },
+    "exclusiveMinimum": {
+      "type": "boolean",
+      "default": false
+    },
+    "maxLength": {
+      "$ref": "#/definitions/positiveInteger"
+    },
+    "minLength": {
+      "$ref": "#/definitions/positiveIntegerDefault0"
+    },
+    "pattern": {
+      "type": "string",
+      "format": "regex"
+    },
+    "additionalItems": {
+      "anyOf": [
+        {
+          "type": "boolean"
+        },
+        {
+          "$ref": "#"
+        }
+      ],
+      "default": {}
+    },
+    "items": {
+      "anyOf": [
+        {
+          "$ref": "#"
+        },
+        {
+          "$ref": "#/definitions/schemaArray"
+        }
+      ],
+      "default": {}
+    },
+    "maxItems": {
+      "$ref": "#/definitions/positiveInteger"
+    },
+    "minItems": {
+      "$ref": "#/definitions/positiveIntegerDefault0"
+    },
+    "uniqueItems": {
+      "type": "boolean",
+      "default": false
+    },
+    "maxProperties": {
+      "$ref": "#/definitions/positiveInteger"
+    },
+    "minProperties": {
+      "$ref": "#/definitions/positiveIntegerDefault0"
+    },
+    "required": {
+      "$ref": "#/definitions/stringArray"
+    },
+    "additionalProperties": {
+      "anyOf": [
+        {
+          "type": "boolean"
+        },
+        {
+          "$ref": "#"
+        }
+      ],
+      "default": {}
+    },
+    "definitions": {
+      "type": "object",
+      "additionalProperties": {
+        "$ref": "#"
+      },
+      "default": {}
+    },
+    "properties": {
+      "type": "object",
+      "additionalProperties": {
+        "$ref": "#"
+      },
+      "default": {}
+    },
+    "patternProperties": {
+      "type": "object",
+      "additionalProperties": {
+        "$ref": "#"
+      },
+      "default": {}
+    },
+    "dependencies": {
+      "type": "object",
+      "additionalProperties": {
+        "anyOf": [
+          {
+            "$ref": "#"
+          },
+          {
+            "$ref": "#/definitions/stringArray"
+          }
+        ]
+      }
+    },
+    "enum": {
+      "type": "array",
+      "minItems": 1,
+      "uniqueItems": true
+    },
+    "type": {
+      "anyOf": [
+        {
+          "$ref": "#/definitions/simpleTypes"
+        },
+        {
+          "type": "array",
+          "items": {
+            "$ref": "#/definitions/simpleTypes"
+          },
+          "minItems": 1,
+          "uniqueItems": true
+        }
+      ]
+    },
+    "format": {
+      "type": "string"
+    },
+    "allOf": {
+      "$ref": "#/definitions/schemaArray"
+    },
+    "anyOf": {
+      "$ref": "#/definitions/schemaArray"
+    },
+    "oneOf": {
+      "$ref": "#/definitions/schemaArray"
+    },
+    "not": {
+      "$ref": "#"
+    },
+    "$ref": {
+      "type": "string"
+    },
+    "omitWhenMerged": {
+      "type": "boolean",
+      "default": false
+    },
+    "deprecated": {
+      "type": "object",
+      "additionalProperties": false,
+      "required": [
+        "deprecatedVersion",
+        "description"
+      ],
+      "properties": {
+        "deprecatedVersion": {
+          "type": "string"
+        },
+        "description": {
+          "type": "string"
+        }
+      }
+    },
+    "codelist": {
+      "type": "string"
+    },
+    "openCodelist": {
+      "type": "boolean",
+      "default": false
+    },
+    "wholeListMerge": {
+      "type": "boolean",
+      "default": false
+    },
+    "versionId": {
+      "type": "boolean",
+      "default": false
+    },
+    "version": {
+      "type": "string"
+    },
+    "propertyOrder": {
+      "type": "integer"
+    }
+  },
+  "dependencies": {
+    "exclusiveMaximum": [
+      "maximum"
+    ],
+    "exclusiveMinimum": [
+      "minimum"
+    ]
+  },
+  "default": {},
+  "additionalProperties": false
+}

--- a/tests/schema/meta-schema.json
+++ b/tests/schema/meta-schema.json
@@ -252,6 +252,9 @@
     },
     "propertyOrder": {
       "type": "integer"
+    },
+    "oneOfEnumSelectorField": {
+      "type": "string"
     }
   },
   "dependencies": {

--- a/tests/test_data.py
+++ b/tests/test_data.py
@@ -439,6 +439,7 @@ def test_all_examples_and_data_files_are_used():
     files_used.extend(test_valid_statement_json_parametrize_data)
     files_used.extend(test_valid_package_json_parametrize_data)
     files_used.extend([a[0] for a in test_invalid_statement_json_parametrize_data])
+    files_used.append('schema/meta-schema.json')
     for data in test_invalid_package_json_parametrize_data:
         if data[0]:
             files_used.append(data[0])

--- a/tests/test_json.py
+++ b/tests/test_json.py
@@ -1,4 +1,4 @@
-from bods_validate import absolute_path_to_source_schema_dir
+from bods_validate import absolute_path_to_source_schema_dir, this_dir
 
 from warnings import warn
 from collections import Counter
@@ -7,9 +7,10 @@ from jscc.testing.util import warn_and_assert
 from jscc.testing.filesystem import walk_json_data, walk_csv_data
 from jscc.schema import is_json_schema
 from jscc.testing.checks import validate_items_type, validate_letter_case, validate_schema
-from jscc.testing.util import http_get
 
 import pytest
+import os
+import json
 
 
 def test_empty():
@@ -32,15 +33,9 @@ def test_invalid_json():
     )
 
 
-schemas = [(path, name, data) for path, name, _, data in walk_json_data() if is_json_schema(data)]
-metaschema = http_get("https://standard.open-contracting.org/schema/1__1__4/meta-schema.json").json()
-
-metaschema["properties"]["version"] = {
-    "type": "string",
-}
-metaschema["properties"]["propertyOrder"] = {
-    "type": "integer",
-}
+schemas = [(path, name, data) for path, name, _, data in walk_json_data() if is_json_schema(data) and not path.endswith('tests/schema/meta-schema.json')]
+with open(os.path.join(this_dir, 'schema', 'meta-schema.json')) as fp:
+    metaschema = json.load(fp)
 
 
 @pytest.mark.parametrize("path,name,data", schemas)


### PR DESCRIPTION
https://github.com/openownership/lib-cove-bods/issues/64

# Overview

## What does this pull request do?

Changes part of schema to be technically correct and add a hint field so we get better validation messages

## How can a reviewer test or examine your changes?

No changes to data model. To see changes in validation messages:
* run Cove locally
* make sure you use version 0.27 of https://github.com/OpenDataServices/lib-cove 
* follow instructions in https://github.com/openownership/lib-cove-bods#updating-schema-files-in-data to make your cove use the new compiled schema files
* try the broken sample data at the top of https://github.com/openownership/lib-cove-bods/issues/64

## Who is best placed to review it?

Already discussed with @rhiaro and @kd-ods 

Relates to issue: https://github.com/openownership/lib-cove-bods/issues/64

## Translations

- :no_entry:  I've notified the translation coordinator of any new strings that will need
      translating. See: https://openownership.github.io/bods-dev-handbook/translations.html - There are none.

## Documentation & Release

- :ok:  I've thought about how and when this needs to be released. See:
      https://openownership.github.io/bods-dev-handbook/standard_releases.html I think this is possible to release in 0.2.1 and that would be better than 0.3 just because users will see the better validation messages faster
- :ok:  I've updated the changelog, if necessary - done
- :no_entry:  I've added or edited any related documentation. See: https://github.com/openownership/bods-dev-handbook/blob/master/style_guide.md - there is none
