### PR TITLE
schema: Various changes around ISO lists

### DIFF
--- a/docs/schema/changelog.rst
+++ b/docs/schema/changelog.rst
@@ -18,12 +18,19 @@ ChangeLog
 Added
 -----
 - Support for describing the traded securities and status of a publicly listed company (PLC): a new ``publicListing`` object has been added to Entity Statements.
+- ``Country.name`` is now a required field (previously it was defined as "MUST" in the description).
+- ``Jurisdiction.name`` is now a required field (previously it was defined as "MUST" in the description).
+- ``SecuritiesListing.stockExchangeJurisdiction`` has minimum and maximum lengths to match the two lists that values could be from.
 
 Changed
 -------
 - The ``interestType`` and ``unspecifiedReason`` codelist codes have been changed from using hyphens to camelCase.
 - ``hasPepStatus`` and ``pepDetails`` are replaced with ``politicalExposure`` object  that contains ``status`` and ``details`` properties.
 - Required fields `statementPointerTarget` and `motivation` are moved from inside the `anyOf` statement to the top level, as they apply to all motivation types.
+- Clarified ``Address.country`` is from the ISO 3166-1 list (previously it was unclear which ISO list was meant and used "digit" when it meant "letter").
+- Clarified ``Country.code`` is from the ISO 3166-1 list (previously it was unclear which ISO list was meant and used "digit" when it meant "letter").
+- Clarified ``Jurisdiction.code`` is from the ISO 3166-1 or ISO 3166-2 list (previously it was unclear which ISO list was meant and used "digit" when it meant "letter").
+- Clarified ``SecuritiesListing.stockExchangeJurisdiction`` is from the ISO 3166-1 or ISO 3166-2 list (previously it was unclear which ISO list was meant and used "digit" when it meant "letter").
 
 
 [0.2] - 2019-06-30

--- a/examples/1-single-direct.json
+++ b/examples/1-single-direct.json
@@ -29,7 +29,8 @@
     "personType": "knownPerson",
     "nationalities": [
       {
-        "code": "GB"
+        "code": "GB",
+        "name": "United Kingdom of Great Britain and Northern Ireland (the)"
       }
     ],
     "names": [

--- a/examples/2-single-update.json
+++ b/examples/2-single-update.json
@@ -29,7 +29,8 @@
     "personType": "knownPerson",
     "nationalities": [
       {
-        "code": "GB"
+        "code": "GB",
+        "name": "United Kingdom of Great Britain and Northern Ireland (the)"
       }
     ],
     "names": [

--- a/examples/3-joint-ownership.json
+++ b/examples/3-joint-ownership.json
@@ -22,7 +22,8 @@
       }
     ],
     "incorporatedInJurisdiction": {
-      "code": "GB"
+      "code": "GB",
+      "name": "United Kingdom of Great Britain and Northern Ireland (the)"
     },
     "publicationDetails": {
       "publicationDate": "2018-11-18",

--- a/examples/4b-full-pep-declaration.json
+++ b/examples/4b-full-pep-declaration.json
@@ -37,7 +37,8 @@
       "details": [
         {
           "jurisdiction": {
-            "code": "gb"
+            "code": "gb",
+            "name": "United Kingdom of Great Britain and Northern Ireland (the)"
           },
           "reason": "Member of Parliament",
           "startDate": "2017-10-15",

--- a/examples/flat-serialisation/gb-coh-bods-package.json
+++ b/examples/flat-serialisation/gb-coh-bods-package.json
@@ -29,7 +29,8 @@
     "personType": "knownPerson",
     "nationalities": [
       {
-        "code": "GB"
+        "code": "GB",
+        "name": "United Kingdom of Great Britain and Northern Ireland (the)"
       }
     ],
     "names": [

--- a/examples/flat-serialisation/gb-coh-person-statement.json
+++ b/examples/flat-serialisation/gb-coh-person-statement.json
@@ -6,7 +6,8 @@
   "personType": "knownPerson",
   "nationalities": [
     {
-      "code": "GB"
+      "code": "GB",
+      "name": "United Kingdom of Great Britain and Northern Ireland (the)"
     }
   ],
   "names": [

--- a/examples/os-01-dr-01.json
+++ b/examples/os-01-dr-01.json
@@ -31,15 +31,18 @@
     "personType": "knownPerson",
     "nationalities": [
       {
-        "code": "GB"
+        "code": "GB",
+        "name": "United Kingdom of Great Britain and Northern Ireland (the)"
       }
     ],
     "taxResidencies": [
       {
-        "code": "GB"
+        "code": "GB",
+        "name": "United Kingdom of Great Britain and Northern Ireland (the)"
       },
       {
-        "code": "UA"
+        "code": "UA",
+        "name": "Ukraine"
       }
     ],
     "names": [

--- a/schema/components.json
+++ b/schema/components.json
@@ -173,7 +173,7 @@
         },
         "country": {
           "title": "Country",
-          "description": "The ISO 2-Digit county code for this address.",
+          "description": "The 2-letter country code (ISO 3166-1) for this address.",
           "type": "string",
           "minLength": 2,
           "maxLength": 2
@@ -426,7 +426,7 @@
     },
     "Country": {
       "title": "Country",
-      "description": "A country MUST have a name. A country SHOULD have an ISO 2-Digit county code.",
+      "description": "A country MUST have a name. A country SHOULD have a 2-letter country code (ISO 3166-1)",
       "type": "object",
       "properties": {
         "name": {
@@ -436,16 +436,19 @@
         },
         "code": {
           "title": "Country code",
-          "description": "The ISO 2-digit code for the country.",
+          "description": "The 2-letter country code (ISO 3166-1) for this country.",
           "type": "string",
           "maxLength": 2,
           "minLength": 2
         }
-      }
+      },
+      "required": [
+        "name"
+      ]
     },
     "Jurisdiction": {
       "title": "Jurisdiction",
-      "description": "A jurisdiction MUST have a name. A jurisdiction SHOULD have an ISO ISO_3166-2 2-Digit country code, or ISO_3166-2 sub-division code.",
+      "description": "A jurisdiction MUST have a name. A jurisdiction SHOULD have the 2-letter country code (ISO 3166-1) or the subdivision code (ISO 3166-2) for the jurisdiction.",
       "type": "object",
       "properties": {
         "name": {
@@ -454,13 +457,16 @@
           "type": "string"
         },
         "code": {
-          "title": "Country code",
-          "description": "The ISO_3166-2 2-Digit country code, or ISO_3166-2 sub-division code of the jurisdiction",
+          "title": "Country or subdivision code",
+          "description": "The 2-letter country code (ISO 3166-1) or the subdivision code (ISO 3166-2) for the jurisdiction.",
           "type": "string",
           "maxLength": 6,
           "minLength": 2
         }
-      }
+      },
+      "required": [
+        "name"
+      ]
     },
     "PepStatusDetails": {
       "title": "PEP Status",
@@ -625,7 +631,9 @@
         "stockExchangeJurisdiction": {
           "type": "string",
           "title": "Stock exchange jurisdiction",
-          "description": "The 2-Digit country code (ISO 3166-2) of the jurisdiction under which the exchange, market or trading platform is regulated."
+          "description": "The 2-letter country code (ISO 3166-1) or the subdivision code (ISO 3166-2) for the jurisdiction under which the exchange, market or trading platform is regulated.",
+          "maxLength": 6,
+          "minLength": 2
         },
         "stockExchangeName": {
           "type": "string",

--- a/tests/data/bods-package/fails-secondary-validation/bods-package-incorrect-ordering.json
+++ b/tests/data/bods-package/fails-secondary-validation/bods-package-incorrect-ordering.json
@@ -58,7 +58,8 @@
     "personType": "knownPerson",
     "nationalities": [
       {
-        "code": "GB"
+        "code": "GB",
+        "name": "United Kingdom of Great Britain and Northern Ireland (the)"
       }
     ],
     "names": [

--- a/tests/data/bods-package/fails-secondary-validation/bods-package-missing-entity-statement.json
+++ b/tests/data/bods-package/fails-secondary-validation/bods-package-missing-entity-statement.json
@@ -7,7 +7,8 @@
     "personType": "knownPerson",
     "nationalities": [
       {
-        "code": "GB"
+        "code": "GB",
+        "name": "United Kingdom of Great Britain and Northern Ireland (the)"
       }
     ],
     "names": [

--- a/tests/data/bods-package/valid/valid-bods-package-annotations.json
+++ b/tests/data/bods-package/valid/valid-bods-package-annotations.json
@@ -46,7 +46,8 @@
       }
     ],
     "incorporatedInJurisdiction": {
-      "code": "GB"
+      "code": "GB",
+      "name": "United Kingdom of Great Britain and Northern Ireland (the)"
     },
     "source": {
       "type": [

--- a/tests/data/bods-package/valid/valid-bods-package.json
+++ b/tests/data/bods-package/valid/valid-bods-package.json
@@ -29,7 +29,8 @@
     "personType": "knownPerson",
     "nationalities": [
       {
-        "code": "GB"
+        "code": "GB",
+        "name": "United Kingdom of Great Britain and Northern Ireland (the)"
       }
     ],
     "names": [

--- a/tests/data/entity-statement/invalid/entity-statement-invalid-date-in-source.json
+++ b/tests/data/entity-statement/invalid/entity-statement-invalid-date-in-source.json
@@ -13,7 +13,8 @@
     }
   ],
   "incorporatedInJurisdiction": {
-    "code": "GB"
+    "code": "GB",
+    "name": "United Kingdom of Great Britain and Northern Ireland (the)"
   },
   "source": {
     "type": [

--- a/tests/data/entity-statement/invalid/entity-statement-no-publication-details.json
+++ b/tests/data/entity-statement/invalid/entity-statement-no-publication-details.json
@@ -13,7 +13,8 @@
     }
   ],
   "incorporatedInJurisdiction": {
-    "code": "GB"
+    "code": "GB",
+    "name": "United Kingdom of Great Britain and Northern Ireland (the)"
   },
   "publicationDetailsTypo": {
     "publicationDate": "2017-11-18",

--- a/tests/data/entity-statement/valid/valid-entity-statement-with-source.json
+++ b/tests/data/entity-statement/valid/valid-entity-statement-with-source.json
@@ -13,7 +13,8 @@
     }
   ],
   "incorporatedInJurisdiction": {
-    "code": "GB"
+    "code": "GB",
+    "name": "United Kingdom of Great Britain and Northern Ireland (the)"
   },
   "source": {
     "type": [

--- a/tests/data/entity-statement/valid/valid-entity-statement.json
+++ b/tests/data/entity-statement/valid/valid-entity-statement.json
@@ -13,7 +13,8 @@
     }
   ],
   "incorporatedInJurisdiction": {
-    "code": "GB"
+    "code": "GB",
+    "name": "United Kingdom of Great Britain and Northern Ireland (the)"
   },
   "publicationDetails": {
     "publicationDate": "2017-11-18",

--- a/tests/data/person-statement/invalid/person-statement-no-bods-version.json
+++ b/tests/data/person-statement/invalid/person-statement-no-bods-version.json
@@ -6,7 +6,8 @@
   "personType": "knownPerson",
   "nationalities": [
     {
-      "code": "GB"
+      "code": "GB",
+      "name": "United Kingdom of Great Britain and Northern Ireland (the)"
     }
   ],
   "names": [

--- a/tests/data/person-statement/invalid/person-statement-no-publication-date.json
+++ b/tests/data/person-statement/invalid/person-statement-no-publication-date.json
@@ -6,7 +6,8 @@
   "personType": "knownPerson",
   "nationalities": [
     {
-      "code": "GB"
+      "code": "GB",
+      "name": "United Kingdom of Great Britain and Northern Ireland (the)"
     }
   ],
   "names": [

--- a/tests/data/person-statement/invalid/person-statement-no-publication-details.json
+++ b/tests/data/person-statement/invalid/person-statement-no-publication-details.json
@@ -6,7 +6,8 @@
   "personType": "knownPerson",
   "nationalities": [
     {
-      "code": "GB"
+      "code": "GB",
+      "name": "United Kingdom of Great Britain and Northern Ireland (the)"
     }
   ],
   "names": [

--- a/tests/data/person-statement/invalid/person-statement-no-publisher-sub-prop.json
+++ b/tests/data/person-statement/invalid/person-statement-no-publisher-sub-prop.json
@@ -6,7 +6,8 @@
   "personType": "knownPerson",
   "nationalities": [
     {
-      "code": "GB"
+      "code": "GB",
+      "name": "United Kingdom of Great Britain and Northern Ireland (the)"
     }
   ],
   "names": [

--- a/tests/data/person-statement/invalid/person-statement-no-publisher.json
+++ b/tests/data/person-statement/invalid/person-statement-no-publisher.json
@@ -6,7 +6,8 @@
   "personType": "knownPerson",
   "nationalities": [
     {
-      "code": "GB"
+      "code": "GB",
+      "name": "United Kingdom of Great Britain and Northern Ireland (the)"
     }
   ],
   "names": [

--- a/tests/data/person-statement/invalid/person-statement-with-bad-bods-version.json
+++ b/tests/data/person-statement/invalid/person-statement-with-bad-bods-version.json
@@ -6,7 +6,8 @@
   "personType": "knownPerson",
   "nationalities": [
     {
-      "code": "GB"
+      "code": "GB",
+      "name": "United Kingdom of Great Britain and Northern Ireland (the)"
     }
   ],
   "names": [

--- a/tests/data/person-statement/invalid/person-statement-with-bad-date.json
+++ b/tests/data/person-statement/invalid/person-statement-with-bad-date.json
@@ -6,7 +6,8 @@
   "personType": "knownPerson",
   "nationalities": [
     {
-      "code": "GB"
+      "code": "GB",
+      "name": "United Kingdom of Great Britain and Northern Ireland (the)"
     }
   ],
   "names": [

--- a/tests/data/person-statement/invalid/person-statement-with-bad-licence-url.json
+++ b/tests/data/person-statement/invalid/person-statement-with-bad-licence-url.json
@@ -6,7 +6,8 @@
   "personType": "knownPerson",
   "nationalities": [
     {
-      "code": "GB"
+      "code": "GB",
+      "name": "United Kingdom of Great Britain and Northern Ireland (the)"
     }
   ],
   "names": [

--- a/tests/data/person-statement/invalid/person-statement-with-bad-publication-date.json
+++ b/tests/data/person-statement/invalid/person-statement-with-bad-publication-date.json
@@ -6,7 +6,8 @@
   "personType": "knownPerson",
   "nationalities": [
     {
-      "code": "GB"
+      "code": "GB",
+      "name": "United Kingdom of Great Britain and Northern Ireland (the)"
     }
   ],
   "names": [

--- a/tests/data/person-statement/invalid/person-statement-with-bad-publisher-url.json
+++ b/tests/data/person-statement/invalid/person-statement-with-bad-publisher-url.json
@@ -6,7 +6,8 @@
   "personType": "knownPerson",
   "nationalities": [
     {
-      "code": "GB"
+      "code": "GB",
+      "name": "United Kingdom of Great Britain and Northern Ireland (the)"
     }
   ],
   "names": [

--- a/tests/data/person-statement/invalid/person-statement-with-invalid-statement-id.json
+++ b/tests/data/person-statement/invalid/person-statement-with-invalid-statement-id.json
@@ -6,7 +6,8 @@
   "personType": "knownPerson",
   "nationalities": [
     {
-      "code": "GB"
+      "code": "GB",
+      "name": "United Kingdom of Great Britain and Northern Ireland (the)"
     }
   ],
   "names": [

--- a/tests/data/person-statement/valid/valid-person-statement.json
+++ b/tests/data/person-statement/valid/valid-person-statement.json
@@ -6,7 +6,8 @@
   "personType": "knownPerson",
   "nationalities": [
     {
-      "code": "GB"
+      "code": "GB",
+      "name": "United Kingdom of Great Britain and Northern Ireland (the)"
     }
   ],
   "names": [


### PR DESCRIPTION
https://github.com/openownership/data-standard/issues/272

# Overview

### What does this pull request do?


Takes @kd-ods  suggestion from:
https://github.com/openownership/data-standard/issues/272#issuecomment-957533718

With edits from @jpmckinney:
https://github.com/openownership/data-standard/issues/272#issuecomment-957967843

And the following extra changes:
* Jurisdiction.description edited
* Jurisdiction.name is required - to mirror country & match the "MUST" in the description
* Jurisdiction.code.title edited 
* I removed some commas from Kadies suggestions that seemed unneeded.
* SecuritiesListing.stockExchangeJurisdiction add min/max length




### How can a reviewer test or examine your changes?

View on ReadTheDocs or build docs locally https://standard.openownership.org/en/272-country-codes/schema/reference.html#address

### Who is best placed to review it?

Any reviewer

Relates to issue: https://github.com/openownership/data-standard/issues/272

## Translations

- [x] I've notified the translation coordinator of any new strings that will need
      translating. See: https://openownership.github.io/bods-dev-handbook/translations.html

## Documentation & Release

- :+1:  I've thought about how and when this needs to be released. See:
      https://openownership.github.io/bods-dev-handbook/standard_releases.html  - Should probably be a minor release, not a patch release.
- :+1:  I've updated the changelog, if necessary - Done
- :-1:  I've added or edited any related documentation. See: https://github.com/openownership/bods-dev-handbook/blob/master/style_guide.md - Not relevant
