### PR TITLE
requirements: Python 3.8, upgrade, remove recommonmark, pypi releases

### DIFF
--- a/docs/_static/theme_overrides.css
+++ b/docs/_static/theme_overrides.css
@@ -1,31 +1,10 @@
-/* override table width restrictions */
-.wy-table-responsive table td, .wy-table-responsive table th {
-    white-space: normal !important;
+
+/** A newer version of docutils aligns center by default. We want the old behavior of left align. **/
+body .align-default {
+    text-align: left !important;
 }
 
-.wy-table-responsive {
-    margin-bottom: 24px;
-    max-width: 100%;
-    overflow: visible !important;
-}
-
-
-.wy-table-responsive th:nth-of-type(1) {
-    width:10%;
-}
-
-.wy-table-responsive th:nth-of-type(2) {
-    width:10%;
-}
-
-.wy-table-responsive th:nth-of-type(3) {
-    width:60%;
-}
-
-.wy-table-responsive th:nth-of-type(4) {
-    width:10%;
-}
-
-.wy-table-responsive th:nth-of-type(5) {
-    width:10%;
+body table.align-default {
+    margin-left: 0 !important;
+    margin-right: auto !important;
 }

--- a/docs/conf.py
+++ b/docs/conf.py
@@ -20,8 +20,6 @@
 # sys.path.insert(0, os.path.abspath('.'))
 import os
 from shutil import copyfile, copy2
-from recommonmark.transform import AutoStructify
-from recommonmark.parser import CommonMarkParser
 
 import json
 import subprocess
@@ -59,10 +57,9 @@ templates_path = ['_templates']
 #
 # source_suffix = ['.rst', '.md']
 source_parsers = {
-    '.md': CommonMarkParser,
     }
 
-source_suffix = ['.rst', '.md']
+source_suffix = ['.rst']
 
 # The encoding of source files.
 #
@@ -118,6 +115,10 @@ html_theme_path = [oods.sphinxtheme.get_html_theme_path()]
 # relative to this directory. They are copied after the builtin static files,
 # so a file named "default.css" will overwrite the builtin "default.css".
 html_static_path = ['_static', '_build_schema']
+
+html_css_files = [
+    "theme_overrides.css"
+]
 
 # Output file base name for HTML help builder.
 htmlhelp_basename = 'BODS'
@@ -288,12 +289,6 @@ def compile_schema_and_codelists():
 
 def setup(app):
     app.add_directive('json-value', JSONValue)
-    app.add_config_value('recommonmark_config', {
-        #'url_resolver': lambda url: github_doc_root + url,
-        'auto_toc_tree_section': 'Contents',
-        'enable_eval_rst': True
-        }, True)
-    app.add_transform(AutoStructify)
     app.connect('build-finished', copy_legacy_redirects)
     language = app.config.overrides.get('language', 'en')
     compile_schema_and_codelists()

--- a/docs/schema/reference.rst
+++ b/docs/schema/reference.rst
@@ -34,6 +34,7 @@ Address
 .. jsonschema:: ../_build_schema/components.json
    :pointer: /definitions/Address
    :externallinks: {"type":{"url":"#addresstype","text":"Codelists"}}
+   :allowexternalrefs:
 
 
 .. note::
@@ -53,6 +54,7 @@ Agent
 .. jsonschema:: ../_build_schema/components.json
    :pointer: /definitions/Agent
    :collapse:
+   :allowexternalrefs:
 
 .. _schema-annotation:
 
@@ -64,6 +66,7 @@ The ``annotations`` property of statements currently allows an array of these si
 .. jsonschema:: ../_build_schema/components.json
    :pointer: /definitions/Annotation
    :externallinks: {"motivation":{"url":"#annotationmotivation","text":"Codelists"}}
+   :allowexternalrefs:
 
 .. _schema-country:
 
@@ -75,6 +78,7 @@ Country
 
 .. jsonschema:: ../_build_schema/components.json
    :pointer: /definitions/Country
+   :allowexternalrefs:
 
 
 .. _schema-entity-statement:
@@ -88,6 +92,7 @@ EntityStatement
 .. jsonschema:: ../_build_schema/entity-statement.json
    :collapse: identifiers,addresses,source,incorporatedInJurisdiction,annotations,publicationDetails
    :externallinks: {"entityType":{"url":"#entitytype","text":"Codelists"}, "unspecifiedEntityDetails/reason":{"url":"#unspecifiedreason","text":"Codelists"}}
+   :allowexternalrefs:
 
 .. _schema-id:
 
@@ -111,6 +116,7 @@ The Identifier object is used to connect a statement to the real-world person or
 
 .. jsonschema:: ../_build_schema/components.json
    :pointer: /definitions/Identifier
+   :allowexternalrefs:
 
 .. _schema-interest:
 
@@ -124,6 +130,7 @@ Interest
    :pointer: /definitions/Interest
    :collapse: share,annotations
    :externallinks: {"share":{"url":"#share","text":"Share"}, "type":{"url":"#interesttype","text":"Codelists"}}
+   :allowexternalrefs:
 
 .. _schema-interested-party:
 
@@ -137,6 +144,7 @@ InterestedParty
    :pointer: /properties/interestedParty
    :collapse:
    :externallinks: {"unspecified/reason":{"url":"#unspecifiedreason","text":"Codelists"}}
+   :allowexternalrefs:
 
 .. _schema-jurisdiction:
 
@@ -148,6 +156,7 @@ Jurisdiction
 
 .. jsonschema:: ../_build_schema/components.json
    :pointer: /definitions/Jurisdiction
+   :allowexternalrefs:
 
 .. _schema-name:
 
@@ -160,6 +169,7 @@ Name
 .. jsonschema:: ../_build_schema/components.json
    :pointer: /definitions/Name
    :externallinks: {"type":{"url":"#nametype","text":"Codelists"}}
+   :allowexternalrefs:
 
 .. _schema-ownership-or-control-statement:
 
@@ -172,6 +182,7 @@ OwnershipOrControlStatement
 
 .. jsonschema:: ../_build_schema/ownership-or-control-statement.json
     :collapse: interests,source,annotations,interestedParty,publicationDetails
+    :allowexternalrefs:
 
 .. _schema-pep-status:
 
@@ -185,6 +196,7 @@ PepStatusDetails
    :pointer: /definitions/PepStatusDetails
    :collapse: jurisdiction,source
    :externallinks: {"source/type":{"url":"#sourcetype","text":"Codelists"}}
+   :allowexternalrefs:
 
 .. _schema-person-statement:
 
@@ -197,6 +209,7 @@ PersonStatement
 .. jsonschema:: ../_build_schema/person-statement.json
    :collapse: names,identifiers,source,placeOfResidence,placeOfBirth,addresses,nationalities,annotations,pepStatusDetails,publicationDetails,taxResidencies
    :externallinks: {"unspecifiedPersonDetails/reason":{"url":"#unspecifiedreason","text":"Codelists"}}
+   :allowexternalrefs:
 
 
 .. _schema-publicationdetails:
@@ -210,6 +223,7 @@ PublicationDetails
 .. jsonschema:: ../_build_schema/components.json
    :pointer: /definitions/PublicationDetails
    :collapse: publisher
+   :allowexternalrefs:
 
 .. _schema-publisher:
 
@@ -221,6 +235,7 @@ Publisher
 
 .. jsonschema:: ../_build_schema/components.json
    :pointer: /definitions/Publisher
+   :allowexternalrefs:
 
 
 
@@ -245,6 +260,7 @@ Share
 
 .. jsonschema:: ../_build_schema/components.json
    :pointer: /definitions/Interest/properties/share
+   :allowexternalrefs:
 
 
 .. _schema-source:
@@ -259,6 +275,7 @@ Source
    :pointer: /definitions/Source
    :collapse: assertedBy
    :externallinks: {"type":{"url":"#sourcetype","text":"Codelists"}}
+   :allowexternalrefs:
 
 
 See :any:`Sources and annotations <provenance>` for a discussion of provenance modelling.

--- a/readthedocs.yml
+++ b/readthedocs.yml
@@ -7,6 +7,6 @@ build:
     image: latest
 
 python:
-   version: 3.5
+   version: 3.8
 
 

--- a/requirements.in
+++ b/requirements.in
@@ -1,11 +1,9 @@
-sphinx==1.7.5
+sphinx>=4.2,<4.3
 sphinx-intl
 transifex-client
 sphinx_rtd_theme
-CommonMark==0.7.5 # Higher versions rename the package which mean we need code changes before we can upgrade, see https://github.com/rtfd/CommonMark-py/blob/master/CHANGELOG.md#080-2018-09-03
--e git+https://github.com/rtfd/recommonmark.git@450909bdcf4c5eafde7c89696006530ba7cc78de#egg=recommonmark
--e git+https://github.com/OpenDataServices/sphinxcontrib-jsonschema.git@8a3982bf7701420e50d69f2341213ced2b18ca54#egg=sphinxcontrib-jsonschema
--e git+https://github.com/OpenDataServices/sphinxcontrib-opendataservices.git@fab0ff0167d32ec243d42f272e0e50766299c078#egg=sphinxcontrib-opendataservices
+sphinxcontrib-opendataservices-jsonschema
+sphinxcontrib-opendataservices
 -e git+https://github.com/openownership/data-standard-sphinx-theme.git@master#egg=standard_theme
 ocds-babel
 urllib3>=1.23

--- a/requirements.txt
+++ b/requirements.txt
@@ -4,19 +4,12 @@
 #
 #    pip-compile
 #
--e git+https://github.com/rtfd/recommonmark.git@450909bdcf4c5eafde7c89696006530ba7cc78de#egg=recommonmark
-    # via
-    #   -r requirements.in
-    #   sphinxcontrib-jsonschema
-    #   sphinxcontrib-opendataservices
--e git+https://github.com/OpenDataServices/sphinxcontrib-jsonschema.git@8a3982bf7701420e50d69f2341213ced2b18ca54#egg=sphinxcontrib-jsonschema
-    # via -r requirements.in
--e git+https://github.com/OpenDataServices/sphinxcontrib-opendataservices.git@fab0ff0167d32ec243d42f272e0e50766299c078#egg=sphinxcontrib-opendataservices
-    # via -r requirements.in
 -e git+https://github.com/openownership/data-standard-sphinx-theme.git@master#egg=standard_theme
     # via -r requirements.in
 alabaster==0.7.12
     # via sphinx
+attrs==21.2.0
+    # via markdown-it-py
 babel==2.9.0
     # via
     #   sphinx
@@ -27,17 +20,13 @@ chardet==4.0.0
     # via requests
 click==7.1.2
     # via sphinx-intl
-commonmark==0.7.5
-    # via
-    #   -r requirements.in
-    #   recommonmark
 docutils==0.16
     # via
-    #   recommonmark
+    #   myst-parser
     #   sphinx
     #   sphinx-rtd-theme
-future==0.18.2
-    # via commonmark
+    #   sphinxcontrib-opendataservices
+    #   sphinxcontrib-opendataservices-jsonschema
 gitdb==4.0.7
     # via gitpython
 gitpython==3.1.15
@@ -47,15 +36,27 @@ idna==2.10
 imagesize==1.2.0
     # via sphinx
 jinja2==2.11.3
-    # via sphinx
+    # via
+    #   myst-parser
+    #   sphinx
 jsonpointer==2.1
     # via
-    #   sphinxcontrib-jsonschema
     #   sphinxcontrib-opendataservices
+    #   sphinxcontrib-opendataservices-jsonschema
 jsonref==0.2
-    # via sphinxcontrib-jsonschema
+    # via sphinxcontrib-opendataservices-jsonschema
+markdown-it-py==1.1.0
+    # via
+    #   mdit-py-plugins
+    #   myst-parser
 markupsafe==1.1.1
     # via jinja2
+mdit-py-plugins==0.2.8
+    # via myst-parser
+myst-parser==0.15.2
+    # via
+    #   sphinxcontrib-opendataservices
+    #   sphinxcontrib-opendataservices-jsonschema
 ocds-babel==0.3.2
     # via -r requirements.in
 packaging==20.9
@@ -70,15 +71,15 @@ python-slugify==4.0.1
     # via transifex-client
 pytz==2021.1
     # via babel
+pyyaml==6.0
+    # via myst-parser
 requests==2.25.1
     # via
     #   -r requirements.in
     #   sphinx
     #   transifex-client
 six==1.15.0
-    # via
-    #   sphinx
-    #   transifex-client
+    # via transifex-client
 smmap==4.0.0
     # via gitdb
 snowballstemmer==2.1.0
@@ -89,25 +90,40 @@ sphinx-intl==2.0.1
     #   standard-theme
 sphinx-rtd-theme==0.5.2
     # via -r requirements.in
-sphinx==1.7.5
+sphinx==4.2.0
     # via
     #   -r requirements.in
-    #   recommonmark
+    #   myst-parser
     #   sphinx-intl
     #   sphinx-rtd-theme
-    #   sphinxcontrib-jsonschema
     #   sphinxcontrib-opendataservices
     #   standard-theme
-sphinxcontrib-serializinghtml==1.1.4
-    # via sphinxcontrib-websupport
-sphinxcontrib-websupport==1.2.4
+sphinxcontrib-applehelp==1.0.2
+    # via sphinx
+sphinxcontrib-devhelp==1.0.2
+    # via sphinx
+sphinxcontrib-htmlhelp==2.0.0
+    # via sphinx
+sphinxcontrib-jsmath==1.0.1
+    # via sphinx
+sphinxcontrib-opendataservices-jsonschema==0.4.0
+    # via
+    #   -r requirements.in
+    #   sphinxcontrib-opendataservices
+sphinxcontrib-opendataservices==0.2.0
+    # via -r requirements.in
+sphinxcontrib-qthelp==1.0.3
+    # via sphinx
+sphinxcontrib-serializinghtml==1.1.5
     # via sphinx
 text-unidecode==1.3
     # via python-slugify
 transifex-client==0.14.2
     # via -r requirements.in
 typing-extensions==3.7.4.3
-    # via gitpython
+    # via
+    #   gitpython
+    #   markdown-it-py
 urllib3==1.26.4
     # via
     #   -r requirements.in

--- a/requirements_test.in
+++ b/requirements_test.in
@@ -18,4 +18,5 @@ jscc
 # See table at bottom of https://python-jsonschema.readthedocs.io/en/latest/validate/#validating-formats
 rfc3987
 strict-rfc3339
--e git+https://github.com/OpenDataServices/compile-to-json-schema.git@v0.3.0#egg=compiletojsonschema
+compiletojsonschema==0.3.0
+

--- a/requirements_test.txt
+++ b/requirements_test.txt
@@ -4,17 +4,6 @@
 #
 #    pip-compile requirements_test.in
 #
--e git+https://github.com/OpenDataServices/compile-to-json-schema.git@v0.3.0#egg=compiletojsonschema
-    # via -r requirements_test.in
--e git+https://github.com/rtfd/recommonmark.git@450909bdcf4c5eafde7c89696006530ba7cc78de#egg=recommonmark
-    # via
-    #   -r requirements.in
-    #   sphinxcontrib-jsonschema
-    #   sphinxcontrib-opendataservices
--e git+https://github.com/OpenDataServices/sphinxcontrib-jsonschema.git@8a3982bf7701420e50d69f2341213ced2b18ca54#egg=sphinxcontrib-jsonschema
-    # via -r requirements.in
--e git+https://github.com/OpenDataServices/sphinxcontrib-opendataservices.git@fab0ff0167d32ec243d42f272e0e50766299c078#egg=sphinxcontrib-opendataservices
-    # via -r requirements.in
 -e git+https://github.com/openownership/data-standard-sphinx-theme.git@master#egg=standard_theme
     # via -r requirements.in
 alabaster==0.7.12
@@ -23,6 +12,7 @@ attrs==20.3.0
     # via
     #   -r requirements_test.in
     #   jsonschema
+    #   markdown-it-py
     #   pytest
 babel==2.9.0
     # via
@@ -36,19 +26,17 @@ click==7.1.2
     # via
     #   pip-tools
     #   sphinx-intl
-commonmark==0.7.5
-    # via
-    #   -r requirements.in
-    #   recommonmark
+compiletojsonschema==0.3.0
+    # via -r requirements_test.in
 docutils==0.16
     # via
-    #   recommonmark
+    #   myst-parser
     #   sphinx
     #   sphinx-rtd-theme
+    #   sphinxcontrib-opendataservices
+    #   sphinxcontrib-opendataservices-jsonschema
 flake8==3.9.1
     # via -r requirements_test.in
-future==0.18.2
-    # via commonmark
 gitdb==4.0.7
     # via gitpython
 gitpython==3.1.15
@@ -67,7 +55,9 @@ importlib-metadata==4.0.1
 iniconfig==1.1.1
     # via pytest
 jinja2==2.11.3
-    # via sphinx
+    # via
+    #   myst-parser
+    #   sphinx
 jscc==0.0.5
     # via -r requirements_test.in
 json-merge-patch==0.2
@@ -76,24 +66,34 @@ json-merge-patch==0.2
     #   jscc
 jsonpointer==2.1
     # via
-    #   sphinxcontrib-jsonschema
     #   sphinxcontrib-opendataservices
+    #   sphinxcontrib-opendataservices-jsonschema
 jsonref==0.2
     # via
     #   compiletojsonschema
     #   jscc
-    #   sphinxcontrib-jsonschema
+    #   sphinxcontrib-opendataservices-jsonschema
 jsonschema==3.2.0
     # via
     #   -r requirements_test.in
     #   compiletojsonschema
     #   jscc
+markdown-it-py==1.1.0
+    # via
+    #   mdit-py-plugins
+    #   myst-parser
 markupsafe==1.1.1
     # via jinja2
 mccabe==0.6.1
     # via
     #   -r requirements_test.in
     #   flake8
+mdit-py-plugins==0.2.8
+    # via myst-parser
+myst-parser==0.15.2
+    # via
+    #   sphinxcontrib-opendataservices
+    #   sphinxcontrib-opendataservices-jsonschema
 ocds-babel==0.3.2
     # via -r requirements.in
 packaging==20.9
@@ -134,6 +134,8 @@ python-slugify==4.0.1
     # via transifex-client
 pytz==2021.1
     # via babel
+pyyaml==6.0
+    # via myst-parser
 requests==2.25.1
     # via
     #   -r requirements.in
@@ -148,7 +150,6 @@ six==1.15.0
     # via
     #   -r requirements_test.in
     #   jsonschema
-    #   sphinx
     #   transifex-client
 smmap==4.0.0
     # via gitdb
@@ -160,18 +161,31 @@ sphinx-intl==2.0.1
     #   standard-theme
 sphinx-rtd-theme==0.5.2
     # via -r requirements.in
-sphinx==1.7.5
+sphinx==4.2.0
     # via
     #   -r requirements.in
-    #   recommonmark
+    #   myst-parser
     #   sphinx-intl
     #   sphinx-rtd-theme
-    #   sphinxcontrib-jsonschema
     #   sphinxcontrib-opendataservices
     #   standard-theme
-sphinxcontrib-serializinghtml==1.1.4
-    # via sphinxcontrib-websupport
-sphinxcontrib-websupport==1.2.4
+sphinxcontrib-applehelp==1.0.2
+    # via sphinx
+sphinxcontrib-devhelp==1.0.2
+    # via sphinx
+sphinxcontrib-htmlhelp==2.0.0
+    # via sphinx
+sphinxcontrib-jsmath==1.0.1
+    # via sphinx
+sphinxcontrib-opendataservices-jsonschema==0.4.0
+    # via
+    #   -r requirements.in
+    #   sphinxcontrib-opendataservices
+sphinxcontrib-opendataservices==0.2.0
+    # via -r requirements.in
+sphinxcontrib-qthelp==1.0.3
+    # via sphinx
+sphinxcontrib-serializinghtml==1.1.5
     # via sphinx
 strict-rfc3339==0.7
     # via
@@ -189,6 +203,7 @@ typing-extensions==3.7.4.3
     # via
     #   gitpython
     #   importlib-metadata
+    #   markdown-it-py
 urllib3==1.26.4
     # via
     #   -r requirements.in


### PR DESCRIPTION
https://github.com/openownership/data-standard/issues/318
https://github.com/openownership/data-standard/issues/226

Start using pypi releases of our libraries.

Have to upgrade Sphinx as myst-parser needs a newer version

Python upgraded needed.
Python 3.8 is the latest version RTD seems to support at this time

theme_overrides.css:

Add CSS classes to get back old behavoir changed by upgrade.

Remove wy-table-responsive css classes.
I couldn't find any place they were being used.
Also the CSS file wasn't loaded before so they were not making a
difference.

Should be no changes to content, so no changelogs, translations, etc.
