### PR TITLE
schema: statementType should not have codelist options

### DIFF
--- a/docs/schema/changelog.rst
+++ b/docs/schema/changelog.rst
@@ -34,6 +34,7 @@ Changed
 - Clarified ``SecuritiesListing.stockExchangeJurisdiction`` is from the ISO 3166-1 or ISO 3166-2 list (previously it was unclear which ISO list was meant and used "digit" when it meant "letter").
 - Annotations changes from a ``anyOf`` to a ``oneOf``. This is technically correct and also is needed to improve validation messages.
 - Descriptions of ``statementType``.
+- Do not reference codelists in ``statementType`` - this and the way we use this field to select which subschema to use for validation cause issues. This should have no change for anyone using the compiled schema but may affect anyone using the files in ``schema/`` directly.
 
 
 [0.2] - 2019-06-30

--- a/docs/schema/changelog.rst
+++ b/docs/schema/changelog.rst
@@ -34,7 +34,7 @@ Changed
 - Clarified ``SecuritiesListing.stockExchangeJurisdiction`` is from the ISO 3166-1 or ISO 3166-2 list (previously it was unclear which ISO list was meant and used "digit" when it meant "letter").
 - Annotations changes from a ``anyOf`` to a ``oneOf``. This is technically correct and also is needed to improve validation messages.
 - Descriptions of ``statementType``.
-- Do not reference codelists in ``statementType`` - this and the way we use this field to select which subschema to use for validation cause issues. This should have no change for anyone using the compiled schema but may affect anyone using the files in ``schema/`` directly.
+- Do not reference codelists in ``statementType`` - fixes issues caused by the way we use this field to select which subschema to use for validation. This should have no change for anyone using the compiled schema but may affect anyone using the files in ``schema/`` directly.
 
 
 [0.2] - 2019-06-30

--- a/schema/entity-statement.json
+++ b/schema/entity-statement.json
@@ -17,9 +17,7 @@
       "enum": [
         "entityStatement"
       ],
-      "propertyOrder": 2,
-      "openCodelist": false,
-      "codelist": "statementType.csv"
+      "propertyOrder": 2
     },
     "statementDate": {
       "$ref": "components.json#/definitions/StatementDate",

--- a/schema/ownership-or-control-statement.json
+++ b/schema/ownership-or-control-statement.json
@@ -15,9 +15,7 @@
       "type": "string",
       "enum": [
         "ownershipOrControlStatement"
-      ],
-      "openCodelist": false,
-      "codelist": "statementType.csv"
+      ]
     },
     "statementDate": {
       "$ref": "components.json#/definitions/StatementDate"

--- a/schema/person-statement.json
+++ b/schema/person-statement.json
@@ -17,9 +17,7 @@
       "enum": [
         "personStatement"
       ],
-      "propertyOrder": 2,
-      "openCodelist": false,
-      "codelist": "statementType.csv"
+      "propertyOrder": 2
     },
     "statementDate": {
       "$ref": "components.json#/definitions/StatementDate",

--- a/tests/test_json.py
+++ b/tests/test_json.py
@@ -87,6 +87,12 @@ def test_codelists_used():
     unused_codelists = [codelist for codelist in codelist_files if codelist not in codelists]
     missing_codelists = [codelist for codelist in codelists if codelist not in codelist_files]
 
+    # because of how we use subschemas and how we use the statementType field to select which subschema to use,
+    # we can't reference the statementType.csv directly from the schema. But it is used in building the docs.
+    # So the file should be on disk, but we will falsely see it as unused in this test.
+    # See https://github.com/openownership/data-standard/issues/375
+    unused_codelists.remove('statementType.csv')
+
     assert len(unused_codelists) == 0, "Codelist files found not in schema: {}".format(unused_codelists)
     assert len(missing_codelists) == 0, "Codelists in schema missing CSVs: {}".format(missing_codelists)
 


### PR DESCRIPTION
https://github.com/openownership/data-standard/issues/375

# Overview

- What does this pull request do?

Fixes a technical issue so compiling a schema for validation is easier.

- How can a reviewer test or examine your changes?

 See new standard at https://standard.openownership.org/en/375-fix-statement-type-codelist

Try and compile schema at https://github.com/openownership/lib-cove-bods#updating-schema-files-in-data - note fix described in those instructions is now longer needed

- Who is best placed to review it?

Have already discussed with @rhiaro 

Closes  issue: #375

## Translations

- :-1:  I've notified the translation coordinator of any new strings that will need
      translating. See: https://openownership.github.io/bods-dev-handbook/translations.html - Not applicable

## Documentation & Release

- [ ] I've thought about how and when this needs to be released. See:
      https://openownership.github.io/bods-dev-handbook/standard_releases.html  - Think this could be 0.2.1 but not totally sure. Can be 0.3 if not.
- :+1:  I've updated the changelog, if necessary. - Not sure it is but done
- :+1:  I've added or edited any related documentation. See: https://github.com/openownership/bods-dev-handbook/blob/master/style_guide.md - there is none
