### PR TITLE
schema: statementType - minor typos in description

### DIFF
--- a/docs/schema/changelog.rst
+++ b/docs/schema/changelog.rst
@@ -33,6 +33,7 @@ Changed
 - Clarified ``Jurisdiction.code`` is from the ISO 3166-1 or ISO 3166-2 list (previously it was unclear which ISO list was meant and used "digit" when it meant "letter").
 - Clarified ``SecuritiesListing.stockExchangeJurisdiction`` is from the ISO 3166-1 or ISO 3166-2 list (previously it was unclear which ISO list was meant and used "digit" when it meant "letter").
 - Annotations changes from a ``anyOf`` to a ``oneOf``. This is technically correct and also is needed to improve validation messages.
+- Descriptions of ``statementType``.
 
 
 [0.2] - 2019-06-30

--- a/schema/entity-statement.json
+++ b/schema/entity-statement.json
@@ -12,7 +12,7 @@
     },
     "statementType": {
       "title": "Statement type",
-      "description": " This should always be 'entityStatement.",
+      "description": "This MUST be 'entityStatement'.",
       "type": "string",
       "enum": [
         "entityStatement"

--- a/schema/ownership-or-control-statement.json
+++ b/schema/ownership-or-control-statement.json
@@ -11,7 +11,7 @@
     },
     "statementType": {
       "title": "Statement type",
-      "description": "This should always be set to `ownershipOrControlStatement`.",
+      "description": "This MUST be 'ownershipOrControlStatement'.",
       "type": "string",
       "enum": [
         "ownershipOrControlStatement"

--- a/schema/person-statement.json
+++ b/schema/person-statement.json
@@ -12,7 +12,7 @@
     },
     "statementType": {
       "title": "Statement type",
-      "description": "This should always be 'personStatement.",
+      "description": "This MUST be 'personStatement'.",
       "type": "string",
       "enum": [
         "personStatement"


### PR DESCRIPTION
https://github.com/openownership/data-standard/issues/381

# Overview

- What does this pull request do?

Fixes minor typos, see issue

- How can a reviewer test or examine your changes?

https://standard.openownership.org/en/381-descriptions/schema/reference.html#entitystatement

- Who is best placed to review it?

Anyone

Closes issue: https://github.com/openownership/data-standard/issues/381

## Translations

- :+1:  I've notified the translation coordinator of any new strings that will need
      translating. See: https://openownership.github.io/bods-dev-handbook/translations.html - in issue

## Documentation & Release

- :+1:  I've thought about how and when this needs to be released. See:
      https://openownership.github.io/bods-dev-handbook/standard_releases.html      - could be 0.2.1
- :+1:  I've updated the changelog, if necessary. - Done
- :-1:  I've added or edited any related documentation. See: https://github.com/openownership/bods-dev-handbook/blob/master/style_guide.md - None
