### PR TITLE
Remove 0.0.3 warning banner

### DIFF
--- a/docs/conformance.md
+++ b/docs/conformance.md
@@ -1,11 +1,6 @@
 Conformance and validation
 ===========================
 
-```eval_rst
-
-  .. warning:: This is an old version of the data standard. `See latest version <https://standard.openownership.org/en/latest/>`_.
-```
-
 ## Conformance statement
 
 * A conforming implementation **may** use only a subset of this specification’s terms.

--- a/docs/credits.md
+++ b/docs/credits.md
@@ -1,13 +1,6 @@
 Credits
 =======
 
-
-```eval_rst
-
-  .. warning:: This is an old version of the data standard. `See latest version <https://standard.openownership.org/en/latest/>`_.
-```
-
-
 The beta version of the Beneficial Ownership Data Standard was written by Tim Davies ([Open Data Services Co-operative](http://www.opendataservices.coop)) with Ben Symonds ([OpenCorporates](http://www.opencorporates.com)), Chris Taggart ([OpenCorporates](http://www.opencorporates.com)) and Jack Lord ([Knowcale](http://knocale.com)) and supported by the [data standard working group](governance.md).
 
 

--- a/docs/examples.md
+++ b/docs/examples.md
@@ -1,12 +1,5 @@
 ## Examples
 
-
-```eval_rst
-
-  .. warning:: This is an old version of the data standard. `See latest version <https://standard.openownership.org/en/latest/>`_.
-```
-
-
 In the [tools folder](https://github.com/openownership/data-standard/) of the schema repository a script is available to generate dummy data, or blank example data files. 
 
 The following manually constructed examples highlight key elements of how beneficial ownership statements can be constructed.

--- a/docs/governance.md
+++ b/docs/governance.md
@@ -1,13 +1,6 @@
 Governance 
 ==========
 
-
-```eval_rst
-
-  .. warning:: This is an old version of the data standard. `See latest version <https://standard.openownership.org/en/latest/>`_.
-```
-
-
 ## Get involved
 
 All changes to the standard draft, documentation and specification take place via GitHub at [https://github.com/openownership/data-standard/](https://github.com/openownership/data-standard/).

--- a/docs/identifiers.md
+++ b/docs/identifiers.md
@@ -1,13 +1,6 @@
 Identifiers
 ===========
 
-
-```eval_rst
-
-  .. warning:: This is an old version of the data standard. `See latest version <https://standard.openownership.org/en/latest/>`_.
-```
-
-
 ## Statement ids
 
 Each statement must have a unique id. This id must be globally unique: such that no two statements from the same organisation, or from different organisations, could ever have the same identifier. 

--- a/docs/index.md
+++ b/docs/index.md
@@ -1,11 +1,6 @@
 Beneficial Ownership Data Standard (beta)
 ==========================================
 
-```eval_rst
-
-  .. warning:: This is an old version of the data standard. `See latest version <https://standard.openownership.org/en/latest/>`_.
-```
-
 This site contains documentation site for the beta version of the Beneficial Ownership Data Standard, developed as part of the OpenOwnership project.
 
 This work is taking place under the auspices of the Open Ownership project. More details on the project are avaiable at [http://www.openownership.org](http://www.openownership.org)

--- a/docs/overview.md
+++ b/docs/overview.md
@@ -1,13 +1,6 @@
 Overview
 ========
 
-
-```eval_rst
-
-  .. warning:: This is an old version of the data standard. `See latest version <https://standard.openownership.org/en/latest/>`_.
-```
-
-
 The beneficial ownership data standard will be made up of two parts:
 
 * A data schema that sets out how beneficial ownership data MUST or SHOULD be formatted for interoperability, and that describes the fields of data that systems MUST or SHOULD provide. 

--- a/docs/provenance.md
+++ b/docs/provenance.md
@@ -34,13 +34,6 @@
 
 ## Provenance Information
 
-
-```eval_rst
-
-  .. warning:: This is an old version of the data standard. `See latest version <https://standard.openownership.org/en/latest/>`_.
-```
-
-
 Provenance information can be attached through use of the ``Source`` object on a ``StatementGroup``, a ``BeneficialOwnershipStatement``, an ``EntityStatement`` or a ``PersonStatement``. 
 
 These can be thought of in a hierarchy:

--- a/docs/schema.md
+++ b/docs/schema.md
@@ -33,13 +33,6 @@
 
 # Specification
 
-
-```eval_rst
-
-  .. warning:: This is an old version of the data standard. `See latest version <https://standard.openownership.org/en/latest/>`_.
-```
-
-
 The beneficial ownership standard is made up of two parts:
 
 * A data schema that sets out how beneficial ownership data MUST or SHOULD be formatted for interoperability, and that describes the fields of data that systems MUST or SHOULD provide. 

--- a/docs/serialization.md
+++ b/docs/serialization.md
@@ -1,13 +1,6 @@
 Serialization
 =============
 
-
-```eval_rst
-
-  .. warning:: This is an old version of the data standard. `See latest version <https://standard.openownership.org/en/latest/>`_.
-```
-
-
 The beta specification does not contain detailed information on serialization. 
 
 However, the specification, defined by a JSON Schema, is designed to support:

--- a/docs/usecases.md
+++ b/docs/usecases.md
@@ -1,13 +1,6 @@
 Use cases
 =========
 
-
-```eval_rst
-
-  .. warning:: This is an old version of the data standard. `See latest version <https://standard.openownership.org/en/latest/>`_.
-```
-
-
 The Beneficial Ownership Data Standard beta has been designed with reference to the requirements of eight use-cases:
 
 * Data supply


### PR DESCRIPTION
Removes manual old version warning banner from 0.0.3 version of docs (as one is automatically provided by readthedocs). For https://github.com/openownership/data-standard-sphinx-theme/issues/67