### PR TITLE
Remove 0.0.2 warning banner

### DIFF
--- a/docs/credits.md
+++ b/docs/credits.md
@@ -1,11 +1,4 @@
 Credits (stub)
 =======
 
-
-```eval_rst
-
-  .. warning:: This is an old version of the data standard. `See latest version <https://standard.openownership.org/en/latest/>`_.
-```
-
-
 Credits for the project will be included here.

--- a/docs/examples.md
+++ b/docs/examples.md
@@ -1,10 +1,3 @@
 ## Examples
 
-
-```eval_rst
-
-  .. warning:: This is an old version of the data standard. `See latest version <https://standard.openownership.org/en/latest/>`_.
-```
-
-
 Examples will be given here shortly.

--- a/docs/governance.md
+++ b/docs/governance.md
@@ -1,11 +1,4 @@
 Governance (stub)
 ==========
 
-
-```eval_rst
-
-  .. warning:: This is an old version of the data standard. `See latest version <https://standard.openownership.org/en/latest/>`_.
-```
-
-
 The governance arrangements for the standard will be documented here.

--- a/docs/identifiers.md
+++ b/docs/identifiers.md
@@ -1,13 +1,6 @@
 Identifiers
 ===========
 
-
-```eval_rst
-
-  .. warning:: This is an old version of the data standard. `See latest version <https://standard.openownership.org/en/latest/>`_.
-```
-
-
 ## Statement ids
 
 Each statement must have a unique id. This id must be globally unique: such that no two statements from the same organisation, or from different organisations, could ever have the same identifier. 

--- a/docs/index.md
+++ b/docs/index.md
@@ -1,13 +1,6 @@
 Beneficial Ownership Data Standard (alpha)
 ==========================================
 
-
-```eval_rst
-
-  .. warning:: This is an old version of the data standard. `See latest version <https://standard.openownership.org/en/latest/>`_.
-```
-
-
 This is a stub documentation site for the alpha version of the Beneficial Ownership Data Standard. 
 
 ## About

--- a/docs/overview.md
+++ b/docs/overview.md
@@ -1,13 +1,6 @@
 Overview (stub)
 ========
 
-
-```eval_rst
-
-  .. warning:: This is an old version of the data standard. `See latest version <https://standard.openownership.org/en/latest/>`_.
-```
-
-
 The standard can be used to guide:
 
 * Data collection

--- a/docs/provenance.md
+++ b/docs/provenance.md
@@ -1,12 +1,5 @@
 ## Provenance Information
 
-
-```eval_rst
-
-  .. warning:: This is an old version of the data standard. `See latest version <https://standard.openownership.org/en/latest/>`_.
-```
-
-
 ```eval_rst
 .. note:: 
 

--- a/docs/schema.md
+++ b/docs/schema.md
@@ -33,13 +33,6 @@
 
 # Schema
 
-
-```eval_rst
-
-  .. warning:: This is an old version of the data standard. `See latest version <https://standard.openownership.org/en/latest/>`_.
-```
-
-
 The beneficial ownership standard is made up of two parts:
 
 * A data schema that sets out how beneficial ownership data MUST or SHOULD be formatted for interoperability, and that describes the fields of data that systems MUST or SHOULD provide. 

--- a/docs/serialization.md
+++ b/docs/serialization.md
@@ -1,11 +1,4 @@
 Serialization (stub)
 =============
 
-
-```eval_rst
-
-  .. warning:: This is an old version of the data standard. `See latest version <https://standard.openownership.org/en/latest/>`_.
-```
-
-
 Information on serialization approaches for the project will be included here.


### PR DESCRIPTION
Removes manual old version warning banner from 0.0.2 version of docs (as one is automatically provided by readthedocs). For openownership/data-standard-sphinx-theme#67