### PR TITLE
Add not latest version warning to 0.1.0

### DIFF
--- a/requirements.in
+++ b/requirements.in
@@ -5,4 +5,4 @@ sphinx_rtd_theme
 -e git+https://github.com/rtfd/recommonmark.git@450909bdcf4c5eafde7c89696006530ba7cc78de#egg=recommonmark
 -e git+https://github.com/OpenDataServices/sphinxcontrib-jsonschema.git@8d0d2bb00742b25707866b0f7a2b6c0c35948c5e#egg=sphinxcontrib-jsonschema
 -e git+https://github.com/OpenDataServices/sphinxcontrib-opendataservices.git@fab0ff0167d32ec243d42f272e0e50766299c078#egg=sphinxcontrib-opendataservices
--e git+https://github.com/openownership/data-standard-sphinx-theme.git@3611c856a18381dbbbc172f5859646bb9927c038#egg=standard_theme
+-e git+https://github.com/openownership/data-standard-sphinx-theme.git@a167d91f20cf8b7cf5663e0d89e54853cc3dba73#egg=standard_theme

--- a/requirements.txt
+++ b/requirements.txt
@@ -4,7 +4,7 @@ sphinx-rtd-theme==0.3.1
 -e git+https://github.com/rtfd/recommonmark.git@450909bdcf4c5eafde7c89696006530ba7cc78de#egg=recommonmark
 -e git+https://github.com/OpenDataServices/sphinxcontrib-jsonschema.git@8d0d2bb00742b25707866b0f7a2b6c0c35948c5e#egg=sphinxcontrib_jsonschema
 -e git+https://github.com/OpenDataServices/sphinxcontrib-opendataservices.git@fab0ff0167d32ec243d42f272e0e50766299c078#egg=sphinxcontrib_opendataservices
--e git+https://github.com/openownership/data-standard-sphinx-theme.git@8b05124bd0c5aae102a0f60f892d4d9fb83e9b4b#egg=standard_theme
+-e git+https://github.com/openownership/data-standard-sphinx-theme.git@a167d91f20cf8b7cf5663e0d89e54853cc3dba73#egg=standard_theme
 ## The following requirements were added by pip freeze:
 alabaster==0.7.10
 Babel==2.6.0
@@ -19,7 +19,7 @@ imagesize==1.0.0
 Jinja2==2.10
 jsonpointer==2.0
 jsonref==0.1
-MarkupSafe==1.0
+markupsafe==1.1.1
 packaging==17.1
 Pygments==2.2.0
 pyparsing==2.2.0


### PR DESCRIPTION
Uses a version of the theme with the "not latest version" warning, for https://github.com/openownership/data-standard-sphinx-theme/issues/67. See also https://github.com/openownership/data-standard-sphinx-theme/pull/74

This references a different data-standard-sphinx-theme commit to that on the main branch as there have been updates to the theme since 0.1.0 was released, so I've inserted the necessary update on a new branch (https://github.com/openownership/data-standard-sphinx-theme/tree/0.1.0-theme) without those updates to avoid breaking old version docs with these or future additional theme changes. It does mean we need to make sure that branch is not deleted in future (we should probably consider versioning the theme in the medium term though). 

I did also have to update another dependency as the older version wouldn't build on readthedocs. This doesn't seem to have affected the 0.1.0 build of the docs, but a review for this would be useful to double check everything works as expected. Preview here: https://standard.openownership.org/en/0.1.1/