### PR TITLE
Editing property title to align with name 'directOrIndirect'

### DIFF
--- a/schema/components.json
+++ b/schema/components.json
@@ -250,7 +250,7 @@
           "openCodelist": false
         },
         "directOrIndirect": {
-          "title": "Interest level",
+          "title": "Direct or indirect",
           "description": "How directly the interest is exercised by the interested party. The value MUST be 'indirect' if intermediate entities or agents are known to exist, and MUST be 'direct' if such intermediaries are known not to exist. Otherwise the value MUST be 'unknown'.",
           "type": "string",
           "enum": [


### PR DESCRIPTION
# Overview

- What does this pull request do?

Tiny, minor edit. Final bit of the work to rename the interestLevel property directOrIndirect.

- How can a reviewer test or examine your changes?

I don't think this editing of the title has any material effect on validation of json examples, or on the docs, or docs build. So a glance should be enough.

- Who is best placed to review it?

@rhiaro - since you did all the main work on this.

(Closes/Relates to) issue: #

## Translations

- [n/a ] I've notified the translation coordinator of any new strings that will need
      translating. See: https://openownership.github.io/bods-dev-handbook/translations.html

## Documentation & Release

- [n/a ] I've thought about how and when this needs to be released. See:
      https://openownership.github.io/bods-dev-handbook/standard_releases.html      
- [n/a ] I've updated the changelog, if necessary.
- [n/a ] I've updated [reference.rst](https://standard.openownership.org/en/latest/schema/reference.html) to reflect any changes to schema structure or naming.
- [n/a ] I've added or edited any other related documentation. See: https://github.com/openownership/bods-dev-handbook/blob/master/style_guide.md
