### PR TITLE
docs: don't translate embedded codelists

### DIFF
--- a/.tx/config
+++ b/.tx/config
@@ -19,7 +19,6 @@ source_file = docs/_build/gettext/svg.pot
 source_lang = en
 type = PO
 
-
 [bods-v02.index]
 file_filter = docs/locale/<lang>/LC_MESSAGES/index.po
 source_file = docs/_build/gettext/index.pot

--- a/docs/schema/reference.rst
+++ b/docs/schema/reference.rst
@@ -301,7 +301,7 @@ Codelists
 AddressType
 +++++++++++
 
-.. csv-table::
+.. csv-table-no-translate::
    :header-rows: 1
    :class: codelist-table
    :file: ../_build_schema/codelists/addressType.csv
@@ -310,7 +310,7 @@ AddressType
 AnnotationMotivation
 ++++++++++++++++++++
 
-.. csv-table::
+.. csv-table-no-translate::
    :header-rows: 1
    :class: codelist-table
    :file: ../_build_schema/codelists/annotationMotivation.csv
@@ -319,16 +319,16 @@ AnnotationMotivation
 EntityType
 ++++++++++
 
-.. csv-table::
+.. csv-table-no-translate::
    :header-rows: 1
    :class: codelist-table
    :file: ../_build_schema/codelists/entityType.csv
 
 
 DirectOrIndirect
-+++++++++++++
+++++++++++++++++
 
-.. csv-table::
+.. csv-table-no-translate::
    :header-rows: 1
    :class: codelist-table
    :file: ../_build_schema/codelists/directOrIndirect.csv
@@ -337,7 +337,7 @@ DirectOrIndirect
 InterestType
 ++++++++++++
 
-.. csv-table::
+.. csv-table-no-translate::
    :header-rows: 1
    :class: codelist-table
    :file: ../_build_schema/codelists/interestType.csv
@@ -346,7 +346,7 @@ InterestType
 NameType
 ++++++++
 
-.. csv-table::
+.. csv-table-no-translate::
    :header-rows: 1
    :class: codelist-table
    :file: ../_build_schema/codelists/nameType.csv
@@ -355,7 +355,7 @@ NameType
 PersonType
 ++++++++++
 
-.. csv-table::
+.. csv-table-no-translate::
    :header-rows: 1
    :class: codelist-table
    :file: ../_build_schema/codelists/personType.csv
@@ -364,7 +364,7 @@ PersonType
 SourceType
 ++++++++++
 
-.. csv-table::
+.. csv-table-no-translate::
    :header-rows: 1
    :class: codelist-table
    :file: ../_build_schema/codelists/sourceType.csv
@@ -373,7 +373,7 @@ SourceType
 StatementType
 +++++++++++++
 
-.. csv-table::
+.. csv-table-no-translate::
    :header-rows: 1
    :class: codelist-table
    :file: ../_build_schema/codelists/statementType.csv
@@ -382,7 +382,7 @@ StatementType
 UnspecifiedReason
 +++++++++++++++++
 
-.. csv-table::
+.. csv-table-no-translate::
    :header-rows: 1
    :class: codelist-table
    :file: ../_build_schema/codelists/unspecifiedReason.csv


### PR DESCRIPTION
# Overview

- What does this pull request do?

Excludes codelist tables in the Schema Reference docs from being exported for translation, as they are redundant.

- How can a reviewer test or examine your changes?

Run `tx pull -a` (to get latest from transifex), then `cd docs` and `make gettext` to extract strings from the documentation. Find the local file `_build/gettextschema/reference.pot` and verify that no strings directly from the codelists are in there (ie. no strings from `../../_build_schema/codelists/*`).

What I haven't done is pushed this up to transifex, since it's currently hooked up to v0.2 and I think that's frozen at the moment, so the redundancy remains on transifex and in the translated `.po` files for the time being.

- Who is best placed to review it?

Anyone familiar with the translations workflow.

(Closes/Relates to) issue: #299

## Translations

- [n/a] I've notified the translation coordinator of any new strings that will need
      translating. See: https://openownership.github.io/bods-dev-handbook/translations.html

## Documentation & Release

- [n/a] I've thought about how and when this needs to be released. See:
      https://openownership.github.io/bods-dev-handbook/standard_releases.html      
- [n/a] I've updated the changelog, if necessary.
- [n/a] I've updated [reference.rst](https://standard.openownership.org/en/latest/schema/reference.html) to reflect any changes to schema structure or naming.
- [n/a] I've added or edited any other related documentation. See: https://github.com/openownership/bods-dev-handbook/blob/master/style_guide.md
