### PR TITLE
tests: only test source schema (ie. not locally built schema), for #401

### DIFF
--- a/tests/test_json.py
+++ b/tests/test_json.py
@@ -33,7 +33,7 @@ def test_invalid_json():
     )
 
 
-schemas = [(path, name, data) for path, name, _, data in walk_json_data() if is_json_schema(data) and not path.endswith('tests/schema/meta-schema.json')]
+schemas = [(path, name, data) for path, name, _, data in walk_json_data(top=absolute_path_to_source_schema_dir) if is_json_schema(data) and not path.endswith('tests/schema/meta-schema.json')]
 with open(os.path.join(this_dir, 'schema', 'meta-schema.json')) as fp:
     metaschema = json.load(fp)
 


### PR DESCRIPTION
# Overview

- What does this pull request do?

Makes the schema/codelists tests more precise by only looking at changes to schema in the source schema directory, rather than scanning the whole data-standard directory for schema files. Previously, if someone had a built version of the schema in their local environment, it would pick these up and run the tests against them as well, which could cause failures if they hadn't been rebuilt since making changes to the sources (see #401).

- How can a reviewer test or examine your changes?

Make a change to a codelist and corresponding schema enums and run the tests (`pytest tests/`).

- Who is best placed to review it?

Anyone familiar with schema edits and running the tests.

(Closes/Relates to) issue: #401

## Translations

- [n/a] I've notified the translation coordinator of any new strings that will need
      translating. See: https://openownership.github.io/bods-dev-handbook/translations.html

## Documentation & Release

- [n/a] I've thought about how and when this needs to be released. See:
      https://openownership.github.io/bods-dev-handbook/standard_releases.html      
- [n/a] I've updated the changelog, if necessary.
- [n/a] I've updated [reference.rst](https://standard.openownership.org/en/latest/schema/reference.html) to reflect any changes to schema structure or naming.
- [n/a] I've added or edited any other related documentation. See: https://github.com/openownership/bods-dev-handbook/blob/master/style_guide.md
