### PR TITLE
Fix docs build warnings

### DIFF
--- a/docs/about/index.rst
+++ b/docs/about/index.rst
@@ -6,10 +6,8 @@ This website contains the specification of `version 0.3 of the Beneficial Owners
 
 BODS is an open standard providing guidance and a structured template for collecting, sharing and using high-quality, machine-readable data on beneficial ownership.
 
-.. cssclass:: h2
-
-        Background
-
+Background
+++++++++++
 
 The utility of beneficial ownership data is enhanced when the data is available in a `structured format <https://www.openownership.org/en/principles/structured-data/>`__. This allows the data to be easily analysed and linked with other datasets, enhancing the data’s ability to expose transnational networks of illicit financial flows and support effective and timely due diligence.
 
@@ -21,9 +19,8 @@ An open :doc:`data standard working group <governance>` of data experts, benefic
 
 The working group is co-chaired by Open Ownership and Open Data Services - and anyone can apply to join the group by `filling out this form <https://docs.google.com/forms/d/e/1FAIpQLSdRSmSUxyyv2t1k3vWXZ_3EhTW_f603MeGxgyjKnbNNE9vvbQ/viewform>`__. Virtual group meetings are held quarterly and communication is coordinated through a :doc:`Google group <governance>`.
 
-.. cssclass:: h2
-
-        Current status of the standard
+Current status of the standard
+++++++++++++++++++++++++++++++
 
 This is v0.3 of the Beneficial Ownership Data Standard. A :ref:`changelog <changelog>` is provided, and the documentation of previous versions is maintained in archive form.
 
@@ -31,9 +28,8 @@ Implementers should be aware that future changes are anticipated before a versio
 
 The `schema <https://standard.openownership.org/en/latest/schema/index.html>`__ contains a structure, fields and codelists but does not yet enforce validation constraints on most fields.
 
-.. cssclass:: h2
-
-        Get involved
+Get involved
+++++++++++++
 
 All changes to the standard draft, documentation and specification take
 place via GitHub at https://github.com/openownership/data-standard/.
@@ -55,10 +51,9 @@ If you would like to be involved in the development and review of the Standard, 
     governance
     credits
     privacy-notice
-       
-.. cssclass:: h2
 
-        Partners and funders
+Partners and funders
+++++++++++++++++++++
 
 The initial development of BODS was funded by Open Ownership as part of a `UK Department for International Development (DfID) <https://www.gov.uk/government/organisations/department-for-international-development>`__ funded project and its development continues to be funded by the `UK Foreign, Commonwealth and Development Office <https://www.gov.uk/government/organisations/foreign-commonwealth-development-office>`__ which replaced DfID.
 
@@ -69,18 +64,18 @@ In order to focus on its mission, Open Ownership is fiscally sponsored by `Globa
 The specification and documentation of BODS have been developed by Open Ownership, Open Data Services and `OpenCorporates <https://opencorporates.com/>`__. Read the
 :doc:`credits <credits>` for full details of the people who have helped develop BODS.
 
-.. cssclass:: h2
-
-        License and contributor agreement
+License and contributor agreement
++++++++++++++++++++++++++++++++++
 
 Schema content of the Open Ownership Register is published under the `GNU Affero General Public License v3.0 <https://github.com/openownership/register/blob/master/LICENSE>`__.
 
 The BODS schema is licensed under the `Apache License, Version 2.0 <https://www.apache.org/licenses/LICENSE-2.0>`__. Stakeholders can use the software for any purpose, to distribute it, to modify it, and to distribute modified versions of the software. Contributors are required to accept the `contributor
 agreement <https://github.com/openownership/data-standard/blob/master/CONTRIBUTING.md>`__.
 
-.. cssclass:: h2
+.. _Contact:
 
-        Contact
+Contact
++++++++
 
 To connect with the data standard support team at Open Ownership, please email
 support@openownership.org.

--- a/docs/about/index.rst
+++ b/docs/about/index.rst
@@ -6,8 +6,23 @@ This website contains the specification of `version 0.3 of the Beneficial Owners
 
 BODS is an open standard providing guidance and a structured template for collecting, sharing and using high-quality, machine-readable data on beneficial ownership.
 
+.. toctree::
+   :hidden:
+   :maxdepth: 1
+
+   governance
+   credits
+   privacy-notice
+
+.. raw:: html
+
+   <h2 id="background">
+
 Background
-++++++++++
+
+.. raw:: html
+
+   </h2>
 
 The utility of beneficial ownership data is enhanced when the data is available in a `structured format <https://www.openownership.org/en/principles/structured-data/>`__. This allows the data to be easily analysed and linked with other datasets, enhancing the data’s ability to expose transnational networks of illicit financial flows and support effective and timely due diligence.
 
@@ -19,8 +34,15 @@ An open :doc:`data standard working group <governance>` of data experts, benefic
 
 The working group is co-chaired by Open Ownership and Open Data Services - and anyone can apply to join the group by `filling out this form <https://docs.google.com/forms/d/e/1FAIpQLSdRSmSUxyyv2t1k3vWXZ_3EhTW_f603MeGxgyjKnbNNE9vvbQ/viewform>`__. Virtual group meetings are held quarterly and communication is coordinated through a :doc:`Google group <governance>`.
 
+.. raw:: html
+
+   <h2 id="current-status-of-the-standard">
+
 Current status of the standard
-++++++++++++++++++++++++++++++
+
+.. raw:: html
+
+   </h2>
 
 This is v0.3 of the Beneficial Ownership Data Standard. A :ref:`changelog <changelog>` is provided, and the documentation of previous versions is maintained in archive form.
 
@@ -28,8 +50,15 @@ Implementers should be aware that future changes are anticipated before a versio
 
 The `schema <https://standard.openownership.org/en/latest/schema/index.html>`__ contains a structure, fields and codelists but does not yet enforce validation constraints on most fields.
 
+.. raw:: html
+
+   <h2 id="get-involved">
+
 Get involved
-++++++++++++
+
+.. raw:: html
+
+   </h2>
 
 All changes to the standard draft, documentation and specification take
 place via GitHub at https://github.com/openownership/data-standard/.
@@ -44,16 +73,15 @@ See the `project issue tracker <https://github.com/openownership/data-standard/i
 
 If you would like to be involved in the development and review of the Standard, see the :doc:`Governance <governance>` page.
 
-.. toctree::
-    :hidden:
-    :maxdepth: 1
+.. raw:: html
 
-    governance
-    credits
-    privacy-notice
+   <h2 id="partners-and-funders">
 
 Partners and funders
-++++++++++++++++++++
+
+.. raw:: html
+
+   </h2>
 
 The initial development of BODS was funded by Open Ownership as part of a `UK Department for International Development (DfID) <https://www.gov.uk/government/organisations/department-for-international-development>`__ funded project and its development continues to be funded by the `UK Foreign, Commonwealth and Development Office <https://www.gov.uk/government/organisations/foreign-commonwealth-development-office>`__ which replaced DfID.
 
@@ -64,18 +92,32 @@ In order to focus on its mission, Open Ownership is fiscally sponsored by `Globa
 The specification and documentation of BODS have been developed by Open Ownership, Open Data Services and `OpenCorporates <https://opencorporates.com/>`__. Read the
 :doc:`credits <credits>` for full details of the people who have helped develop BODS.
 
+.. raw:: html
+
+   <h2 id="license-and-contributor-agreement">
+
 License and contributor agreement
-+++++++++++++++++++++++++++++++++
+
+.. raw:: html
+
+   </h2>
 
 Schema content of the Open Ownership Register is published under the `GNU Affero General Public License v3.0 <https://github.com/openownership/register/blob/master/LICENSE>`__.
 
 The BODS schema is licensed under the `Apache License, Version 2.0 <https://www.apache.org/licenses/LICENSE-2.0>`__. Stakeholders can use the software for any purpose, to distribute it, to modify it, and to distribute modified versions of the software. Contributors are required to accept the `contributor
 agreement <https://github.com/openownership/data-standard/blob/master/CONTRIBUTING.md>`__.
 
-.. _Contact:
+.. _contact:
+
+.. raw:: html
+
+   <h2 id="contact">
 
 Contact
-+++++++
+
+.. raw:: html
+
+   </h2>
 
 To connect with the data standard support team at Open Ownership, please email
 support@openownership.org.

--- a/docs/schema/concepts.rst
+++ b/docs/schema/concepts.rst
@@ -109,7 +109,7 @@ This allows control via arrangements to be modelled in two steps, describing how
 * Person P has an interest in Arrangement A
 * Arrangement A has an interest in Entity E
 
-For more guidance on modelling arrangements, contact the :any:`BODS Helpdesk <support>`.
+For more guidance on modelling arrangements, contact the :any:`BODS Helpdesk <Contact>`.
 
 Direct and indirect ownership and control
 -----------------------------------------

--- a/docs/schema/reference.rst
+++ b/docs/schema/reference.rst
@@ -212,7 +212,7 @@ PersonStatement
 
 .. jsonschema:: ../_build_schema/person-statement.json
    :collapse: names,identifiers,source,placeOfResidence,placeOfBirth,addresses,nationalities,annotations,politicalExposure/details,publicationDetails,taxResidencies
-   :externallinks: {"unspecifiedPersonDetails/reason":{"url":"#unspecifiedreason","text":"UnspecifiedReason"}}
+   :externallinks: {"personType":{"url": "#persontype","text":"PersonType"}, "unspecifiedPersonDetails/reason":{"url":"#unspecifiedreason","text":"UnspecifiedReason"}}
    :allowexternalrefs:
 
 

--- a/docs/schema/reference.rst
+++ b/docs/schema/reference.rst
@@ -92,7 +92,7 @@ EntityStatement
    :pointer: /description
 
 .. jsonschema:: ../_build_schema/entity-statement.json
-   :collapse: identifiers,addresses,source,incorporatedInJurisdiction,annotations,publicationDetails,publicListing
+   :collapse: identifiers,addresses,source,jurisdiction,annotations,publicationDetails,publicListing
    :externallinks: {"entityType":{"url":"#entitytype","text":"EntityType"}, "unspecifiedEntityDetails/reason":{"url":"#unspecifiedreason","text":"UnspecifiedReason"}}
    :allowexternalrefs:
 

--- a/docs/usecases.rst
+++ b/docs/usecases.rst
@@ -224,4 +224,4 @@ Control.
 To give an example user story: *National EITI groups may wish to check
 reported information against data from national beneficial ownership
 registers where those exist, and to be able to address inaccuracies with
-the reporting parties. *
+the reporting parties.*


### PR DESCRIPTION
# Overview

Fixes some minor bugs in the documentation:

* Headers on About page used CSS instead of HTML for subheadings (not accessible, and inconsistent with rest of docs).
* Link to `support` from Schema > Concepts went to a page that [had been deleted](https://github.com/openownership/data-standard/commit/29279b163c08cbcaa78d65ae504796380cc852a5#diff-8054c3a0a30617900afb4c82a08bf99357c72c8aeaa89255d0bc5066792580f8) so changed this to link to Contact section on About page (which has the same text).
* Stray space in Use Cases markup.

## Translations

- [x] New or edited strings appearing as a result of this PR will be picked up for translation
- [x] I've notified the translation coordinator of any new strings that will need
      translating. See: https://openownership.github.io/bods-dev-handbook/translations.html

## Documentation & Release

- [x] I've thought about how and when this needs to be released. See:
      https://openownership.github.io/bods-dev-handbook/standard_releases.html      
- [x] I've updated the changelog, if necessary.
- [x] I've updated [reference.rst](https://standard.openownership.org/en/latest/schema/reference.html) to reflect any changes to schema structure or naming.
- [x] I've added or edited any other related documentation. See: https://github.com/openownership/bods-dev-handbook/blob/master/style_guide.md
