### PR TITLE
Add entitySubtypeCategory codelist to ref pg

### DIFF
--- a/docs/schema/reference.rst
+++ b/docs/schema/reference.rst
@@ -93,7 +93,7 @@ EntityStatement
 
 .. jsonschema:: ../_build_schema/entity-statement.json
    :collapse: identifiers,addresses,source,jurisdiction,annotations,publicationDetails,publicListing
-   :externallinks: {"entityType":{"url":"#entitytype","text":"EntityType"}, "unspecifiedEntityDetails/reason":{"url":"#unspecifiedreason","text":"UnspecifiedReason"}}
+   :externallinks: {"entityType":{"url":"#entitytype","text":"EntityType"},"entitySubtype/generalCategory":{"url":"#entitysubtypecategory","text":"EntitySubtypeCategory"}, "unspecifiedEntityDetails/reason":{"url":"#unspecifiedreason","text":"UnspecifiedReason"}}
    :allowexternalrefs:
 
 .. _schema-id:
@@ -349,6 +349,15 @@ AnnotationMotivation
    :file: ../_build_schema/codelists/annotationMotivation.csv
 
 
+DirectOrIndirect
+++++++++++++++++
+
+.. csv-table-no-translate::
+   :header-rows: 1
+   :class: codelist-table
+   :file: ../_build_schema/codelists/directOrIndirect.csv
+
+
 EntityType
 ++++++++++
 
@@ -358,13 +367,15 @@ EntityType
    :file: ../_build_schema/codelists/entityType.csv
 
 
-DirectOrIndirect
-++++++++++++++++
+
+EntitySubtypeCategory
++++++++++++++++++++++
 
 .. csv-table-no-translate::
    :header-rows: 1
    :class: codelist-table
-   :file: ../_build_schema/codelists/directOrIndirect.csv
+   :file: ../_build_schema/codelists/entitySubtypeCategory.csv
+
 
 
 InterestType


### PR DESCRIPTION
# Overview

- What does this pull request do?

I'd mistakenly missed adding the new entitySubtypeCategory codelist to reference.rst. So I've added it. I also moved the DirectOrIndirect codelist to maintain alphabetical order.

- How can a reviewer test or examine your changes?

Build the docs locally and check that the link to the codelist from the Entity Statement table is working as expected.

- Who is best placed to review it?

@siwhitehouse 

(Closes/Relates to) issue: # n/a

## Translations

n/a

## Documentation & Release

n/a
