### PR TITLE
Schema: rationalize dates, fixes #162

### DIFF
--- a/docs/schema/changelog.rst
+++ b/docs/schema/changelog.rst
@@ -13,7 +13,7 @@ ChangeLog
     The schema specifies a **structure**, **fields** and **codelists** but does not yet enforce validation constraints on most fields.
 
 [Unreleased]
-==================
+=======
 
 Changed
 -------

--- a/docs/schema/changelog.rst
+++ b/docs/schema/changelog.rst
@@ -27,6 +27,10 @@ Alterations to schema structure and logic
   - `id` to `$id`
   - `definitions` to `$defs`
   - `enum`s with one value are now `const`
+- Updated which date formats are valid for all date fields.
+  - Interest `startDate` and `endDate`, PEP Status `startDate` and `endDate`, Entity `foundingDate` and `dissolutionDate`, and formedByStatute `date` are more strict - only date (YYYY-MM-DD) is valid; timestamps and partial dates are no longer valid.
+  - Person `birthDate` and `deathDate` are more strict - year (YYYY), year and month (YYYY-MM) and year, month and day (YYYY-MM-DD) are valid, but timestamps are no longer valid.
+  - Annotation `creationDate`, PublicationDetails `publicationDate` are less strict - valid as date or date-time (partial dates are still not valid).
 
 [0.3] - 2022-04-15
 ==================

--- a/docs/schema/reference.rst
+++ b/docs/schema/reference.rst
@@ -322,9 +322,6 @@ Dates MUST conform with the extended format of `ISO 8601 <https://en.wikipedia.o
 
 * A full datetime string (YYYY-MM-DDTHH:MM:SSZ)
 * A year, month and day (YYYY-MM-DD)
-* A year and month (YYYY-MM)
-* A year (YYYY)
-
 
 .. _schema-codelists:
 

--- a/schema/components.json
+++ b/schema/components.json
@@ -5,9 +5,16 @@
   "$defs": {
     "StatementDate": {
       "title": "Statement date",
-      "description": "The date on which this statement was made.",
+      "description": "The date (optionally including time) on which this statement was declared by the source.",
       "type": "string",
-      "format": "date"
+      "anyOf": [
+        {
+          "format": "date"
+        },
+        {
+          "format": "date-time"
+        }
+      ]
     },
     "Source": {
       "title": "Source",
@@ -44,9 +51,16 @@
         },
         "retrievedAt": {
           "title": "Retrieved at",
-          "description": "If this statement was imported from some external system, include a timestamp indicating when this took place. The statement's own date should be set based on the source information. ",
+          "description": "A timestamp indicating when this statement was imported from an external system, in YYYY-MM-DDTHH:MM:SS or YYYY-MM-DD format. (The statementDate should be set based on the source information.)",
           "type": "string",
-          "format": "date-time"
+          "anyOf": [
+            {
+              "format": "date"
+            },
+            {
+              "format": "date-time"
+            }
+          ]
         },
         "assertedBy": {
           "title": "Asserted by",
@@ -323,15 +337,15 @@
         },
         "startDate": {
           "title": "Start date",
-          "description": "When did this interest first occur. Please provide as precise a date as possible in ISO 8601 format. When only the year or year and month is known, these can be given as YYYY or YYYY-MM.",
+          "description": "The date from which this interest was active. The date MUST be given in YYYY-MM-DD format. Where a precise month or date are unknown, the value may be rounded to the first day of the month. This rounding SHOULD be noted in accompanying guidance for users of the data.",
           "type": "string",
-          "pattern": "^([\\+-]?\\d{4}(?!\\d{2}\b))((-?)((0[1-9]|1[0-2])(\\3([12]\\d|0[1-9]|3[01]))?|W([0-4]\\d|5[0-2])(-?[1-7])?|(00[1-9]|0[1-9]\\d|[12]\\d{2}|3([0-5]\\d|6[1-6])))([T\\s]((([01]\\d|2[0-3])((:?)[0-5]\\d)?|24\\:?00)([\\.,]\\d+(?!:))?)?(\\17[0-5]\\d([\\.,]\\d+)?)?([zZ]|([\\+-])([01]\\d|2[0-3]):?([0-5]\\d)?)?)?)?$"
+          "format": "date"
         },
         "endDate": {
           "title": "End date",
-          "description": "When did this interest cease. Please provide as precise a date as possible in ISO 8601 format. When only the year or year and month is known, these can be given as YYYY or YYYY-MM.",
+          "description": "The date from which this interest ceased to exist. The date MUST be given in YYYY-MM-DD format. Where a precise month or date are unknown, the value may be rounded to the first day of the month. This rounding SHOULD be noted in accompanying guidance for users of the data.",
           "type": "string",
-          "pattern": "^([\\+-]?\\d{4}(?!\\d{2}\b))((-?)((0[1-9]|1[0-2])(\\3([12]\\d|0[1-9]|3[01]))?|W([0-4]\\d|5[0-2])(-?[1-7])?|(00[1-9]|0[1-9]\\d|[12]\\d{2}|3([0-5]\\d|6[1-6])))([T\\s]((([01]\\d|2[0-3])((:?)[0-5]\\d)?|24\\:?00)([\\.,]\\d+(?!:))?)?(\\17[0-5]\\d([\\.,]\\d+)?)?([zZ]|([\\+-])([01]\\d|2[0-3]):?([0-5]\\d)?)?)?)?$"
+          "format": "date"
         }
       }
     },
@@ -347,9 +361,16 @@
         },
         "creationDate": {
           "title": "Creation Date",
-          "description": "The date this annotation was created.",
+          "description": "The date at which this annotation was created, in YYYY-MM-DDTHH:MM:SS or YYYY-MM-DD format.",
           "type": "string",
-          "format": "date"
+          "anyOf": [
+            {
+              "format": "date"
+            },
+            {
+              "format": "date-time"
+            }
+          ]
         },
         "createdBy": {
           "title": "Created By",
@@ -498,15 +519,15 @@
         },
         "startDate": {
           "title": "State date",
-          "description": "When did this PEP status begin. Please provide as precise a date as possible in ISO 8601 format. When only the year or year and month is known, these can be given as YYYY or YYYY-MM.",
+          "description": "The date from which this individual had the status of a Politically-exposed Person (PEP). The date MUST be given in YYYY-MM-DD format. Where a precise month or date are unknown, the value may be rounded to the first day of the month. This rounding SHOULD be noted in accompanying guidance for users of the data.",
           "type": "string",
-          "pattern": "^([\\+-]?\\d{4}(?!\\d{2}\b))((-?)((0[1-9]|1[0-2])(\\3([12]\\d|0[1-9]|3[01]))?|W([0-4]\\d|5[0-2])(-?[1-7])?|(00[1-9]|0[1-9]\\d|[12]\\d{2}|3([0-5]\\d|6[1-6])))([T\\s]((([01]\\d|2[0-3])((:?)[0-5]\\d)?|24\\:?00)([\\.,]\\d+(?!:))?)?(\\17[0-5]\\d([\\.,]\\d+)?)?([zZ]|([\\+-])([01]\\d|2[0-3]):?([0-5]\\d)?)?)?)?$"
+          "format": "date"
         },
         "endDate": {
           "title": "End date",
-          "description": "When did this PEP status end. Please provide as precise a date as possible in ISO 8601 format. When only the year or year and month is known, these can be given as YYYY or YYYY-MM.",
+          "description": "The date from which this individual no longer had the status of a Politically-exposed Person (PEP). The date MUST be given in YYYY-MM-DD format. Where a precise month or date are unknown, the value may be rounded to the first day of the month. This rounding SHOULD be noted in accompanying guidance for users of the data..",
           "type": "string",
-          "pattern": "^([\\+-]?\\d{4}(?!\\d{2}\b))((-?)((0[1-9]|1[0-2])(\\3([12]\\d|0[1-9]|3[01]))?|W([0-4]\\d|5[0-2])(-?[1-7])?|(00[1-9]|0[1-9]\\d|[12]\\d{2}|3([0-5]\\d|6[1-6])))([T\\s]((([01]\\d|2[0-3])((:?)[0-5]\\d)?|24\\:?00)([\\.,]\\d+(?!:))?)?(\\17[0-5]\\d([\\.,]\\d+)?)?([zZ]|([\\+-])([01]\\d|2[0-3]):?([0-5]\\d)?)?)?)?$"
+          "format": "date"
         },
         "source": {
           "title": "Source",
@@ -522,9 +543,16 @@
       "properties": {
         "publicationDate": {
           "title": "Publication date",
-          "description": "The date on which this statement was published.",
+          "description": "The date on which this statement was published, in YYYY-MM-DDTHH:MM:SS or YYYY-MM-DD format.",
           "type": "string",
-          "format": "date"
+          "anyOf": [
+            {
+              "format": "date"
+            },
+            {
+              "format": "date-time"
+            }
+          ]
         },
         "bodsVersion": {
           "title": "BODS version",

--- a/schema/entity-statement.json
+++ b/schema/entity-statement.json
@@ -109,16 +109,16 @@
     },
     "foundingDate": {
       "title": "Founding date",
-      "description": "When was this entity founded, created or registered. Please provide as precise a date as possible in ISO 8601 format. When only the year or year and month is known, these can be given as YYYY or YYYY-MM.",
+      "description": "The date on which this entity was founded, created or registered. The date MUST be given in YYYY-MM-DD format. Where a precise month or date are unknown, the value may be rounded to the first day of the month. This rounding SHOULD be noted in accompanying guidance for users of the data.",
       "type": "string",
-      "pattern": "^([\\+-]?\\d{4}(?!\\d{2}\b))((-?)((0[1-9]|1[0-2])(\\3([12]\\d|0[1-9]|3[01]))?|W([0-4]\\d|5[0-2])(-?[1-7])?|(00[1-9]|0[1-9]\\d|[12]\\d{2}|3([0-5]\\d|6[1-6])))([T\\s]((([01]\\d|2[0-3])((:?)[0-5]\\d)?|24\\:?00)([\\.,]\\d+(?!:))?)?(\\17[0-5]\\d([\\.,]\\d+)?)?([zZ]|([\\+-])([01]\\d|2[0-3]):?([0-5]\\d)?)?)?)?$",
+      "format": "date",
       "propertyOrder": 30
     },
     "dissolutionDate": {
       "title": "Dissolution date",
-      "description": "If this entity is no longer active, provide the date on which it was disolved or ceased. Please provide as precise a date as possible in ISO 8601 format. When only the year or year and month is known, these can be given as YYYY or YYYY-MM.",
+      "description": "The date on which this entity was disolved or ceased if it is no longer active. The date MUST be given in YYYY-MM-DD format. Where a precise month or date are unknown, the value may be rounded to the first day of the month. This rounding SHOULD be noted in accompanying guidance for users of the data.",
       "type": "string",
-      "pattern": "^([\\+-]?\\d{4}(?!\\d{2}\b))((-?)((0[1-9]|1[0-2])(\\3([12]\\d|0[1-9]|3[01]))?|W([0-4]\\d|5[0-2])(-?[1-7])?|(00[1-9]|0[1-9]\\d|[12]\\d{2}|3([0-5]\\d|6[1-6])))([T\\s]((([01]\\d|2[0-3])((:?)[0-5]\\d)?|24\\:?00)([\\.,]\\d+(?!:))?)?(\\17[0-5]\\d([\\.,]\\d+)?)?([zZ]|([\\+-])([01]\\d|2[0-3]):?([0-5]\\d)?)?)?)?$",
+      "format": "date",
       "propertyOrder": 35
     },
     "addresses": {
@@ -208,8 +208,8 @@
         "date": {
           "type": "string",
           "title": "Date",
-          "description": "The date on which the law was passed. The date SHOULD be in the form YYYY-MM-DD. When only the year or year and month is known, these can be given as YYYY or YYYY-MM.",
-          "pattern": "^([\\+-]?\\d{4}(?!\\d{2}\b))((-?)((0[1-9]|1[0-2])(\\3([12]\\d|0[1-9]|3[01]))?|W([0-4]\\d|5[0-2])(-?[1-7])?|(00[1-9]|0[1-9]\\d|[12]\\d{2}|3([0-5]\\d|6[1-6])))([T\\s]((([01]\\d|2[0-3])((:?)[0-5]\\d)?|24\\:?00)([\\.,]\\d+(?!:))?)?(\\17[0-5]\\d([\\.,]\\d+)?)?([zZ]|([\\+-])([01]\\d|2[0-3]):?([0-5]\\d)?)?)?)?$"
+          "description": "The date on which the law came into force. The date MUST be given in YYYY-MM-DD format. Where a precise month or date are unknown, the value may be rounded to the first day of the month. This rounding SHOULD be noted in accompanying guidance for users of the data.",
+          "format": "date"
         }
       },
       "propertyOrder": 18

--- a/schema/person-statement.json
+++ b/schema/person-statement.json
@@ -105,16 +105,30 @@
     },
     "birthDate": {
       "title": "Date of birth",
-      "description": "The date of birth for this individual. Please provide as precise a date as possible in ISO 8601 format. When only the year or year and month is known, these can be given as YYYY or YYYY-MM.",
+      "description": "The date of birth for this individual, in YYYY, YYYY-MM, or YYYY-MM-DD format.",
       "type": "string",
-      "pattern": "^([\\+-]?\\d{4}(?!\\d{2}\b))((-?)((0[1-9]|1[0-2])(\\3([12]\\d|0[1-9]|3[01]))?|W([0-4]\\d|5[0-2])(-?[1-7])?|(00[1-9]|0[1-9]\\d|[12]\\d{2}|3([0-5]\\d|6[1-6])))([T\\s]((([01]\\d|2[0-3])((:?)[0-5]\\d)?|24\\:?00)([\\.,]\\d+(?!:))?)?(\\17[0-5]\\d([\\.,]\\d+)?)?([zZ]|([\\+-])([01]\\d|2[0-3]):?([0-5]\\d)?)?)?)?$",
+      "anyOf": [
+        {
+          "pattern": "^(\\d{4})(-(1[0-2]|0[1-9]))?$"
+        },
+        {
+          "format": "date"
+        }
+      ],
       "propertyOrder": 35
     },
     "deathDate": {
       "title": "Death date",
-      "description": "If this individual is no longer alive, provide their date of death. Please provide as precise a date as possible in ISO 8601 format. When only the year or year and month is known, these can be given as YYYY or YYYY-MM.",
+      "description": "The date of death for this individual, in YYYY, YYYY-MM, or YYYY-MM-DD format.",
       "type": "string",
-      "pattern": "^([\\+-]?\\d{4}(?!\\d{2}\b))((-?)((0[1-9]|1[0-2])(\\3([12]\\d|0[1-9]|3[01]))?|W([0-4]\\d|5[0-2])(-?[1-7])?|(00[1-9]|0[1-9]\\d|[12]\\d{2}|3([0-5]\\d|6[1-6])))([T\\s]((([01]\\d|2[0-3])((:?)[0-5]\\d)?|24\\:?00)([\\.,]\\d+(?!:))?)?(\\17[0-5]\\d([\\.,]\\d+)?)?([zZ]|([\\+-])([01]\\d|2[0-3]):?([0-5]\\d)?)?)?)?$",
+      "anyOf": [
+        {
+          "pattern": "^(\\d{4})(-(1[0-2]|0[1-9]))?$"
+        },
+        {
+          "format": "date"
+        }
+      ],
       "propertyOrder": 36
     },
     "placeOfResidence": {

--- a/tests/data/entity-statement/invalid/entity-statement-invalid-date-in-source.json
+++ b/tests/data/entity-statement/invalid/entity-statement-invalid-date-in-source.json
@@ -27,7 +27,7 @@
         "name": "OPEN DATA SERVICES CO-OPERATIVE LIMITED"
       }
     ],
-    "retrievedAt": "2018-11-14"
+    "retrievedAt": "2018-11"
   },
   "publicationDetails": {
     "publicationDate": "2018-12-24",

--- a/tests/data/entity-statement/invalid/invalid-entity-statement-plc-invalid-idScheme.json
+++ b/tests/data/entity-statement/invalid/invalid-entity-statement-plc-invalid-idScheme.json
@@ -1,7 +1,7 @@
 [
   {
     "entityType": "legalEntity",
-    "foundingDate": "1992-06-17T00:00:00+00:00",
+    "foundingDate": "1992-06-17",
     "identifiers": [
       {
         "id": "02723534",

--- a/tests/data/entity-statement/invalid/invalid-entity-statement-plc-no-security.json
+++ b/tests/data/entity-statement/invalid/invalid-entity-statement-plc-no-security.json
@@ -1,7 +1,7 @@
 [
   {
     "entityType": "legalEntity",
-    "foundingDate": "1992-06-17T00:00:00+00:00",
+    "foundingDate": "1992-06-17",
     "identifiers": [
       {
         "id": "02723534",

--- a/tests/data/entity-statement/invalid/invalid-entity-statement-plc-no-stockExchangeJurisdiction.json
+++ b/tests/data/entity-statement/invalid/invalid-entity-statement-plc-no-stockExchangeJurisdiction.json
@@ -1,7 +1,7 @@
 [
   {
     "entityType": "legalEntity",
-    "foundingDate": "1992-06-17T00:00:00+00:00",
+    "foundingDate": "1992-06-17",
     "identifiers": [
       {
         "id": "02723534",

--- a/tests/data/entity-statement/invalid/invalid-entity-statement-plc-no-stockExchangeName.json
+++ b/tests/data/entity-statement/invalid/invalid-entity-statement-plc-no-stockExchangeName.json
@@ -1,7 +1,7 @@
 [
   {
     "entityType": "legalEntity",
-    "foundingDate": "1992-06-17T00:00:00+00:00",
+    "foundingDate": "1992-06-17",
     "identifiers": [
       {
         "id": "02723534",

--- a/tests/data/entity-statement/invalid/invalid-entity-statement-plc-no-ticker.json
+++ b/tests/data/entity-statement/invalid/invalid-entity-statement-plc-no-ticker.json
@@ -1,7 +1,7 @@
 [
   {
     "entityType": "legalEntity",
-    "foundingDate": "1992-06-17T00:00:00+00:00",
+    "foundingDate": "1992-06-17",
     "identifiers": [
       {
         "id": "02723534",

--- a/tests/data/entity-statement/valid/valid-entity-statement-plc-no-securitiesListings-provided.json
+++ b/tests/data/entity-statement/valid/valid-entity-statement-plc-no-securitiesListings-provided.json
@@ -1,7 +1,7 @@
 [
   {
     "entityType": "legalEntity",
-    "foundingDate": "1992-06-17T00:00:00+00:00",
+    "foundingDate": "1992-06-17",
     "identifiers": [
       {
         "id": "02723534",

--- a/tests/data/entity-statement/valid/valid-entity-statement-plc.json
+++ b/tests/data/entity-statement/valid/valid-entity-statement-plc.json
@@ -1,7 +1,7 @@
 [
   {
     "entityType": "legalEntity",
-    "foundingDate": "1992-06-17T00:00:00+00:00",
+    "foundingDate": "1992-06-17",
     "identifiers": [
       {
         "id": "02723534",

--- a/tests/data/person-statement/invalid/person-statement-with-bad-birthdate.json
+++ b/tests/data/person-statement/invalid/person-statement-with-bad-birthdate.json
@@ -1,0 +1,41 @@
+{
+  "statementID": "019a93f1-e470-42e9-957b-03559861b2e2",
+  "statementType": "personStatement",
+  "isComponent": false,
+  "statementDate": "2018-04-12",
+  "personType": "knownPerson",
+  "nationalities": [
+    {
+      "code": "GB",
+      "name": "United Kingdom of Great Britain and Northern Ireland (the)"
+    }
+  ],
+  "names": [
+    {
+      "type": "individual",
+      "fullName": "Christopher Taggart",
+      "givenName": "Christopher",
+      "familyName": "Taggart"
+    },
+    {
+      "type": "alternative",
+      "fullName": "Chris Taggart"
+    }
+  ],
+  "birthDate": "1964-04-01T12:34:56",
+  "addresses": [
+    {
+      "type": "service",
+      "address": "Aston House, Cornwall Avenue, London",
+      "country": "GB",
+      "postCode": "N3 1LF"
+    }
+  ],
+  "publicationDetails": {
+    "publicationDate": "2017-11-18",
+    "bodsVersion": "0.4",
+    "publisher": {
+      "name": "CHRINON LTD"
+    }
+  }
+}

--- a/tests/test_data.py
+++ b/tests/test_data.py
@@ -138,6 +138,7 @@ test_invalid_statement_json_parametrize_data = [
     ("invalid-entity-statement-stateBody-no-entitySubtype-category.json", ValidationError),
     ("person-statement-with-invalid-statement-id.json", ValidationError),
     ("person-statement-with-bad-date.json", ValidationError),
+    ("person-statement-with-bad-birthdate.json", ValidationError),
     ("person-statement-no-publication-details.json", ValidationError),
     ("person-statement-no-bods-version.json", ValidationError),
     ("person-statement-no-publication-date.json", ValidationError),
@@ -257,7 +258,13 @@ test_invalid_statement_json_iter_errors_parametrize_data = [
     (
         "person-statement-with-bad-date.json",
         {
-            "'Tuesday' is not a 'date'",
+            "'Tuesday' is not valid under any of the given schemas",
+        },
+    ),
+    (
+        "person-statement-with-bad-birthdate.json",
+        {
+            "'1964-04-01T12:34:56' is not valid under any of the given schemas",
         },
     ),
     (
@@ -303,7 +310,7 @@ test_invalid_statement_json_iter_errors_parametrize_data = [
     (
         "person-statement-with-bad-publication-date.json",
         {
-            "'2017/11/18' is not a 'date'",
+            "'2017/11/18' is not valid under any of the given schemas",
         },
     ),
     (
@@ -315,7 +322,7 @@ test_invalid_statement_json_iter_errors_parametrize_data = [
     (
         "entity-statement-invalid-date-in-source.json",
         {
-            "'2018-11-14' is not a 'date-time'",
+            "'2018-11' is not valid under any of the given schemas",
         },
     ),
     (


### PR DESCRIPTION
# Overview

- What does this pull request do?

Simplifies dates as detailed in #162

- Interest `startDate` and `endDate`, PEP Status `startDate` and `endDate`, Entity `foundingDate` and `dissolutionDate`, and formedByStatute `date` are more strict - only date (YYYY-MM-DD) is valid; timestamps and partial dates are no longer valid.
- Person `birthDate` and `deathDate` are more strict - year (YYYY), year and month (YYYY-MM) and year, month and day (YYYY-MM-DD) are valid, but timestamps are no longer valid.
- Annotation `creationDate`, PublicationDetails `publicationDate` are less strict - valid as date or date-time (partial dates are still not valid).

Updates tests/date and adds a couple of extra tests.

- How can a reviewer test or examine your changes?

Check the new schema descriptions and definitions against [the spreadsheet](https://docs.google.com/spreadsheets/d/1dQ1o0llbyxRSTCu0sX05AkGMB3RJEvzVmrJhswISv94/edit#gid=0)

- Who is best placed to review it?

@kd-ods 

(Closes/Relates to) issue: #162

## Translations

- [x] New or edited strings appearing as a result of this PR will be picked up for translation
- [x] I've notified the translation coordinator of any new strings that will need
      translating. See: https://openownership.github.io/bods-dev-handbook/translations.html

## Documentation & Release

- [x] I've thought about how and when this needs to be released. See:
      https://openownership.github.io/bods-dev-handbook/standard_releases.html      
- [x] I've updated the changelog, if necessary.
- [x] I've updated [reference.rst](https://standard.openownership.org/en/latest/schema/reference.html) to reflect any changes to schema structure or naming.
- [x] I've added or edited any other related documentation. See: https://github.com/openownership/bods-dev-handbook/blob/master/style_guide.md
