### PR TITLE
changing subheadings in reference page to include spaces

### DIFF
--- a/docs/schema/changelog.rst
+++ b/docs/schema/changelog.rst
@@ -13,7 +13,7 @@ ChangeLog
     The schema specifies a **structure**, **fields** and **codelists** but does not yet enforce validation constraints on most fields.
 
 [Unreleased]
-============
+=======
 
 Changed
 -------

--- a/docs/schema/changelog.rst
+++ b/docs/schema/changelog.rst
@@ -13,7 +13,7 @@ ChangeLog
     The schema specifies a **structure**, **fields** and **codelists** but does not yet enforce validation constraints on most fields.
 
 [Unreleased]
-=======
+============
 
 Changed
 -------

--- a/docs/schema/concepts.rst
+++ b/docs/schema/concepts.rst
@@ -86,7 +86,7 @@ An ``ownershipOrControlStatement`` connects (via ``statementID`` references) the
 * A person described by a ``personStatement``; or
 * An unspecified party and the reasons that no ownership or control can be specified. 
 
-The ownership-or-control statement also contains an array of ``interests``, each with a type (selected from the `Interest Type codelist <reference.html#interest-type>`_) and, where relevant, percentages indicating the size of the interest. 
+The ownership-or-control statement also contains an array of ``interests``, each with a type (selected from the `interestType codelist <reference.html#interesttype>`_) and, where relevant, percentages indicating the size of the interest. 
 
 To explore the structure of the data model in full use the :doc:`Schema browser <schema-browser>`. Or read the :any:`Schema reference <schema-reference>` for detailed definitions of each object and field. 
 

--- a/docs/schema/concepts.rst
+++ b/docs/schema/concepts.rst
@@ -86,7 +86,7 @@ An ``ownershipOrControlStatement`` connects (via ``statementID`` references) the
 * A person described by a ``personStatement``; or
 * An unspecified party and the reasons that no ownership or control can be specified. 
 
-The ownership-or-control statement also contains an array of ``interests``, each with a type (selected from the `interestType codelist <reference.html#interesttype>`_) and, where relevant, percentages indicating the size of the interest. 
+The ownership-or-control statement also contains an array of ``interests``, each with a type (selected from the `Interest Type codelist <reference.html#interest-type>`_) and, where relevant, percentages indicating the size of the interest. 
 
 To explore the structure of the data model in full use the :doc:`Schema browser <schema-browser>`. Or read the :any:`Schema reference <schema-reference>` for detailed definitions of each object and field. 
 

--- a/docs/schema/reference.rst
+++ b/docs/schema/reference.rst
@@ -85,8 +85,8 @@ Country
 
 .. _schema-entity-statement:
 
-EntityStatement
----------------
+Entity Statement
+----------------
 
 .. json-value:: ../_build_schema/entity-statement.json
    :pointer: /description
@@ -136,8 +136,8 @@ Interest
 
 .. _schema-interested-party:
 
-InterestedParty
----------------
+Interested Party
+----------------
 
 .. json-value:: ../_build_schema/ownership-or-control-statement.json
    :pointer: /$defs/InterestedParty/description
@@ -175,8 +175,8 @@ Name
 
 .. _schema-ownership-or-control-statement:
 
-OwnershipOrControlStatement
----------------------------
+Ownership Or Control Statement
+------------------------------
 
 If a person is a beneficial owner of an entity - whether directly or indirectly - and the person or entity is required to declare this beneficial ownership, there MUST be an Ownership-or-control Statement connecting the two which represents the beneficial ownership relationship. See :ref:`representing-bo` for detailed requirements.
 
@@ -190,8 +190,8 @@ If a person is a beneficial owner of an entity - whether directly or indirectly 
 
 .. _schema-pep-status:
 
-PepStatusDetails
-----------------
+Pep Status Details
+------------------
 
 .. json-value:: ../_build_schema/components.json
    :pointer: /$defs/PepStatusDetails/description
@@ -204,8 +204,8 @@ PepStatusDetails
 
 .. _schema-person-statement:
 
-PersonStatement
----------------
+Person Statement
+----------------
 
 .. json-value:: ../_build_schema/person-statement.json
    :pointer: /description
@@ -218,8 +218,8 @@ PersonStatement
 
 .. _schema-public-listing:
 
-PublicListing
----------------
+Public Listing
+--------------
 
 .. json-value:: ../_build_schema/components.json
    :pointer: /$defs/PublicListing/description
@@ -231,8 +231,8 @@ PublicListing
 
 .. _schema-publicationdetails:
 
-PublicationDetails
-------------------
+Publication Details
+-------------------
 
 .. json-value:: ../_build_schema/components.json
    :pointer: /$defs/PublicationDetails/description
@@ -258,8 +258,8 @@ Publisher
 
 .. _schema-replaces-statements:
 
-ReplacesStatements
-------------------
+Replaces Statements
+-------------------
 
 .. json-value:: ../_build_schema/components.json
    :pointer: /$defs/ReplacesStatements/description
@@ -269,8 +269,8 @@ See :any:`Updating statements <guidance-updating-data>` for technical guidance o
 
 .. _schema-securities-listing:
 
-SecuritiesListing
------------------
+Securities Listing
+------------------
 
 .. json-value:: ../_build_schema/components.json
    :pointer: /$defs/SecuritiesListing/description
@@ -315,8 +315,8 @@ See :any:`Sources and annotations <provenance>` for a discussion of provenance m
 
 .. _schema-statement-date:
 
-StatementDate
--------------
+Statement Date
+--------------
 
 Dates MUST conform with the extended format of `ISO 8601 <https://en.wikipedia.org/wiki/ISO_8601>`_. All of the following, for example, are valid:
 
@@ -328,8 +328,8 @@ Dates MUST conform with the extended format of `ISO 8601 <https://en.wikipedia.o
 Codelists
 ---------
 
-AddressType
-+++++++++++
+Address Type
+++++++++++++
 
 .. csv-table-no-translate::
    :header-rows: 1
@@ -337,8 +337,8 @@ AddressType
    :file: ../_build_schema/codelists/addressType.csv
 
 
-AnnotationMotivation
-++++++++++++++++++++
+Annotation Motivation
++++++++++++++++++++++
 
 .. csv-table-no-translate::
    :header-rows: 1
@@ -346,8 +346,8 @@ AnnotationMotivation
    :file: ../_build_schema/codelists/annotationMotivation.csv
 
 
-DirectOrIndirect
-++++++++++++++++
+Direct Or Indirect
+++++++++++++++++++
 
 .. csv-table-no-translate::
    :header-rows: 1
@@ -355,8 +355,8 @@ DirectOrIndirect
    :file: ../_build_schema/codelists/directOrIndirect.csv
 
 
-EntityType
-++++++++++
+Entity Type
++++++++++++
 
 .. csv-table-no-translate::
    :header-rows: 1
@@ -365,8 +365,8 @@ EntityType
 
 
 
-EntitySubtypeCategory
-+++++++++++++++++++++
+Entity Subtype Category
++++++++++++++++++++++++
 
 .. csv-table-no-translate::
    :header-rows: 1
@@ -375,8 +375,8 @@ EntitySubtypeCategory
 
 
 
-InterestType
-++++++++++++
+Interest Type
++++++++++++++
 
 .. csv-table-no-translate::
    :header-rows: 1
@@ -384,8 +384,8 @@ InterestType
    :file: ../_build_schema/codelists/interestType.csv
 
 
-NameType
-++++++++
+Name Type
++++++++++
 
 .. csv-table-no-translate::
    :header-rows: 1
@@ -393,8 +393,8 @@ NameType
    :file: ../_build_schema/codelists/nameType.csv
 
 
-PersonType
-++++++++++
+Person Type
++++++++++++
 
 .. csv-table-no-translate::
    :header-rows: 1
@@ -402,8 +402,8 @@ PersonType
    :file: ../_build_schema/codelists/personType.csv
 
 
-SecuritiesIdentifierSchemes
-+++++++++++++++++++++++++++
+Securities Identifier Schemes
++++++++++++++++++++++++++++++
 
 .. csv-table-no-translate::
    :header-rows: 1
@@ -411,8 +411,8 @@ SecuritiesIdentifierSchemes
    :file: ../_build_schema/codelists/securitiesIdentifierSchemes.csv
 
 
-SourceType
-++++++++++
+Source Type
++++++++++++
 
 .. csv-table-no-translate::
    :header-rows: 1
@@ -420,8 +420,8 @@ SourceType
    :file: ../_build_schema/codelists/sourceType.csv
 
 
-StatementType
-+++++++++++++
+Statement Type
+++++++++++++++
 
 .. csv-table-no-translate::
    :header-rows: 1
@@ -429,8 +429,8 @@ StatementType
    :file: ../_build_schema/codelists/statementType.csv
 
 
-UnspecifiedReason
-+++++++++++++++++
+Unspecified Reason
+++++++++++++++++++
 
 .. csv-table-no-translate::
    :header-rows: 1

--- a/docs/schema/reference.rst
+++ b/docs/schema/reference.rst
@@ -35,7 +35,7 @@ Address
 
 .. jsonschema:: ../_build_schema/components.json
    :pointer: /$defs/Address
-   :externallinks: {"type":{"url":"#addresstype","text":"AddressType"}}
+   :externallinks: {"type":{"url":"#address-type","text":"Address Type"}}
    :allowexternalrefs:
 
 
@@ -67,7 +67,7 @@ The ``annotations`` property of statements currently allows an array of these si
 
 .. jsonschema:: ../_build_schema/components.json
    :pointer: /$defs/Annotation
-   :externallinks: {"motivation":{"url":"#annotationmotivation","text":"AnnotationMotivation"}}
+   :externallinks: {"motivation":{"url":"#annotation-motivation","text":"Annotation Motivation"}}
    :allowexternalrefs:
 
 .. _schema-country:
@@ -93,7 +93,7 @@ Entity Statement
 
 .. jsonschema:: ../_build_schema/entity-statement.json
    :collapse: identifiers,addresses,source,jurisdiction,annotations,publicationDetails,publicListing
-   :externallinks: {"entityType":{"url":"#entitytype","text":"EntityType"},"entitySubtype/generalCategory":{"url":"#entitysubtypecategory","text":"EntitySubtypeCategory"}, "unspecifiedEntityDetails/reason":{"url":"#unspecifiedreason","text":"UnspecifiedReason"}}
+   :externallinks: {"statementDate":{"url":"#statement-date","text":"Statement Date"},"entityType":{"url":"#entity-type","text":"Entity Type"},"entitySubtype/generalCategory":{"url":"#entity-subtype-category","text":"Entity Subtype Category"}, "unspecifiedEntityDetails/reason":{"url":"#unspecified-reason","text":"Unspecified Reason"},"replacesStatements":{"url":"#replaces-statements","text":"Replaces Statements"},"publicationDetails":{"url":"#publication-details","text":"Publication Details"},"publicListing":{"url":"#public-listing","text":"Public Listing"}}
    :allowexternalrefs:
 
 .. _schema-id:
@@ -131,7 +131,7 @@ Interest
 .. jsonschema:: ../_build_schema/components.json
    :pointer: /$defs/Interest
    :collapse: share
-   :externallinks: {"share":{"url":"#share","text":"Share"}, "type":{"url":"#interesttype","text":"InterestType"}}
+   :externallinks: {"share":{"url":"#share","text":"Share"}, "type":{"url":"#interest-type","text":"Interest Type"}}
    :allowexternalrefs:
 
 .. _schema-interested-party:
@@ -145,7 +145,7 @@ Interested Party
 .. jsonschema:: ../_build_schema/ownership-or-control-statement.json
    :pointer: /properties/interestedParty
    :collapse:
-   :externallinks: {"unspecified/reason":{"url":"#unspecifiedreason","text":"UnspecifiedReason"}}
+   :externallinks: {"unspecified/reason":{"url":"#unspecified-reason","text":"Unspecified Reason"}}
    :allowexternalrefs:
 
 .. _schema-jurisdiction:
@@ -170,7 +170,7 @@ Name
 
 .. jsonschema:: ../_build_schema/components.json
    :pointer: /$defs/Name
-   :externallinks: {"type":{"url":"#nametype","text":"NameType"}}
+   :externallinks: {"type":{"url":"#name-type","text":"Name Type"}}
    :allowexternalrefs:
 
 .. _schema-ownership-or-control-statement:
@@ -185,12 +185,14 @@ If a person is a beneficial owner of an entity - whether directly or indirectly 
 
 
 .. jsonschema:: ../_build_schema/ownership-or-control-statement.json
+    :externallinks: {"statementDate":{"url":"#statement-date","text":"Statement Date"},"interestedParty":{"url":"#interested-party","text":"Interested Party"},"replacesStatements":{"url":"#replaces-statements","text":"Replaces Statements"},"publicationDetails":{"url":"#publication-details","text":"Publication Details"}}
     :collapse: interests,source,annotations,interestedParty,publicationDetails
     :allowexternalrefs:
 
+
 .. _schema-pep-status:
 
-Pep Status Details
+PEP Status Details
 ------------------
 
 .. json-value:: ../_build_schema/components.json
@@ -199,7 +201,7 @@ Pep Status Details
 .. jsonschema:: ../_build_schema/components.json
    :pointer: /$defs/PepStatusDetails
    :collapse: jurisdiction,source
-   :externallinks: {"source/type":{"url":"#sourcetype","text":"SourceType"}}
+   :externallinks: {"source/type":{"url":"#source-type","text":"Source Type"}}
    :allowexternalrefs:
 
 .. _schema-person-statement:
@@ -212,7 +214,7 @@ Person Statement
 
 .. jsonschema:: ../_build_schema/person-statement.json
    :collapse: names,identifiers,source,placeOfResidence,placeOfBirth,addresses,nationalities,annotations,politicalExposure/details,publicationDetails,taxResidencies
-   :externallinks: {"personType":{"url": "#persontype","text":"PersonType"}, "unspecifiedPersonDetails/reason":{"url":"#unspecifiedreason","text":"UnspecifiedReason"}}
+   :externallinks: {"statementDate":{"url":"#statement-date","text":"Statement Date"},"personType":{"url": "#person-type","text":"Person Type"}, "unspecifiedPersonDetails/reason":{"url":"#unspecified-reason","text":"Unspecified Reason"},"replacesStatements":{"url":"#replaces-statements","text":"Replaces Statements"},"publicationDetails":{"url":"#publication-details","text":"Publication Details"},"politicalExposure/details":{"url":"#pep-status-details","text":"PEP Status Details"}}
    :allowexternalrefs:
 
 
@@ -227,6 +229,7 @@ Public Listing
 .. jsonschema:: ../_build_schema/components.json
    :pointer: /$defs/PublicListing
    :collapse: securitiesListings
+   :externallinks: {"securitiesListings":{"url":"#securities-listing","text":"Securities Listing"}}
    :allowexternalrefs:
 
 .. _schema-publicationdetails:
@@ -280,7 +283,7 @@ See :any:`Real world identifiers <guidance-identifiers-other>` for technical gui
 
 .. jsonschema:: ../_build_schema/components.json
    :pointer: /$defs/SecuritiesListing
-   :externallinks: {"security/idScheme":{"url":"#securitiesidentifierschemes","text":"SecuritiesIdentifierSchemes"}}
+   :externallinks: {"security/idScheme":{"url":"#securities-identifier-schemes","text":"Securities Identifier Schemes"}}
    :allowexternalrefs:
 
 .. _schema-share:
@@ -307,7 +310,7 @@ Source
 .. jsonschema:: ../_build_schema/components.json
    :pointer: /$defs/Source
    :collapse: assertedBy
-   :externallinks: {"type":{"url":"#sourcetype","text":"SourceType"}}
+   :externallinks: {"type":{"url":"#source-type","text":"Source Type"}}
    :allowexternalrefs:
 
 

--- a/docs/schema/reference.rst
+++ b/docs/schema/reference.rst
@@ -35,7 +35,7 @@ Address
 
 .. jsonschema:: ../_build_schema/components.json
    :pointer: /$defs/Address
-   :externallinks: {"type":{"url":"#address-type","text":"Address Type"}}
+   :externallinks: {"type":{"url":"#addresstype","text":"AddressType"}}
    :allowexternalrefs:
 
 
@@ -67,7 +67,7 @@ The ``annotations`` property of statements currently allows an array of these si
 
 .. jsonschema:: ../_build_schema/components.json
    :pointer: /$defs/Annotation
-   :externallinks: {"motivation":{"url":"#annotation-motivation","text":"Annotation Motivation"}}
+   :externallinks: {"motivation":{"url":"#annotationmotivation","text":"AnnotationMotivation"}}
    :allowexternalrefs:
 
 .. _schema-country:
@@ -93,7 +93,7 @@ Entity Statement
 
 .. jsonschema:: ../_build_schema/entity-statement.json
    :collapse: identifiers,addresses,source,jurisdiction,annotations,publicationDetails,publicListing
-   :externallinks: {"statementDate":{"url":"#statement-date","text":"Statement Date"},"entityType":{"url":"#entity-type","text":"Entity Type"},"entitySubtype/generalCategory":{"url":"#entity-subtype-category","text":"Entity Subtype Category"}, "unspecifiedEntityDetails/reason":{"url":"#unspecified-reason","text":"Unspecified Reason"},"replacesStatements":{"url":"#replaces-statements","text":"Replaces Statements"},"publicationDetails":{"url":"#publication-details","text":"Publication Details"},"publicListing":{"url":"#public-listing","text":"Public Listing"}}
+   :externallinks: {"entityType":{"url":"#entitytype","text":"EntityType"},"entitySubtype/generalCategory":{"url":"#entitysubtypecategory","text":"EntitySubtypeCategory"}, "unspecifiedEntityDetails/reason":{"url":"#unspecifiedreason","text":"UnspecifiedReason"}}
    :allowexternalrefs:
 
 .. _schema-id:
@@ -131,7 +131,7 @@ Interest
 .. jsonschema:: ../_build_schema/components.json
    :pointer: /$defs/Interest
    :collapse: share
-   :externallinks: {"share":{"url":"#share","text":"Share"}, "type":{"url":"#interest-type","text":"Interest Type"}}
+   :externallinks: {"share":{"url":"#share","text":"Share"}, "type":{"url":"#interesttype","text":"InterestType"}}
    :allowexternalrefs:
 
 .. _schema-interested-party:
@@ -145,7 +145,7 @@ Interested Party
 .. jsonschema:: ../_build_schema/ownership-or-control-statement.json
    :pointer: /properties/interestedParty
    :collapse:
-   :externallinks: {"unspecified/reason":{"url":"#unspecified-reason","text":"Unspecified Reason"}}
+   :externallinks: {"unspecified/reason":{"url":"#unspecifiedreason","text":"UnspecifiedReason"}}
    :allowexternalrefs:
 
 .. _schema-jurisdiction:
@@ -170,7 +170,7 @@ Name
 
 .. jsonschema:: ../_build_schema/components.json
    :pointer: /$defs/Name
-   :externallinks: {"type":{"url":"#name-type","text":"Name Type"}}
+   :externallinks: {"type":{"url":"#nametype","text":"NameType"}}
    :allowexternalrefs:
 
 .. _schema-ownership-or-control-statement:
@@ -185,14 +185,12 @@ If a person is a beneficial owner of an entity - whether directly or indirectly 
 
 
 .. jsonschema:: ../_build_schema/ownership-or-control-statement.json
-    :externallinks: {"statementDate":{"url":"#statement-date","text":"Statement Date"},"interestedParty":{"url":"#interested-party","text":"Interested Party"},"replacesStatements":{"url":"#replaces-statements","text":"Replaces Statements"},"publicationDetails":{"url":"#publication-details","text":"Publication Details"}}
     :collapse: interests,source,annotations,interestedParty,publicationDetails
     :allowexternalrefs:
 
-
 .. _schema-pep-status:
 
-PEP Status Details
+Pep Status Details
 ------------------
 
 .. json-value:: ../_build_schema/components.json
@@ -201,7 +199,7 @@ PEP Status Details
 .. jsonschema:: ../_build_schema/components.json
    :pointer: /$defs/PepStatusDetails
    :collapse: jurisdiction,source
-   :externallinks: {"source/type":{"url":"#source-type","text":"Source Type"}}
+   :externallinks: {"source/type":{"url":"#sourcetype","text":"SourceType"}}
    :allowexternalrefs:
 
 .. _schema-person-statement:
@@ -214,7 +212,7 @@ Person Statement
 
 .. jsonschema:: ../_build_schema/person-statement.json
    :collapse: names,identifiers,source,placeOfResidence,placeOfBirth,addresses,nationalities,annotations,politicalExposure/details,publicationDetails,taxResidencies
-   :externallinks: {"statementDate":{"url":"#statement-date","text":"Statement Date"},"personType":{"url": "#person-type","text":"Person Type"}, "unspecifiedPersonDetails/reason":{"url":"#unspecified-reason","text":"Unspecified Reason"},"replacesStatements":{"url":"#replaces-statements","text":"Replaces Statements"},"publicationDetails":{"url":"#publication-details","text":"Publication Details"},"politicalExposure/details":{"url":"#pep-status-details","text":"PEP Status Details"}}
+   :externallinks: {"personType":{"url": "#persontype","text":"PersonType"}, "unspecifiedPersonDetails/reason":{"url":"#unspecifiedreason","text":"UnspecifiedReason"}}
    :allowexternalrefs:
 
 
@@ -229,7 +227,6 @@ Public Listing
 .. jsonschema:: ../_build_schema/components.json
    :pointer: /$defs/PublicListing
    :collapse: securitiesListings
-   :externallinks: {"securitiesListings":{"url":"#securities-listing","text":"Securities Listing"}}
    :allowexternalrefs:
 
 .. _schema-publicationdetails:
@@ -283,7 +280,7 @@ See :any:`Real world identifiers <guidance-identifiers-other>` for technical gui
 
 .. jsonschema:: ../_build_schema/components.json
    :pointer: /$defs/SecuritiesListing
-   :externallinks: {"security/idScheme":{"url":"#securities-identifier-schemes","text":"Securities Identifier Schemes"}}
+   :externallinks: {"security/idScheme":{"url":"#securitiesidentifierschemes","text":"SecuritiesIdentifierSchemes"}}
    :allowexternalrefs:
 
 .. _schema-share:
@@ -310,7 +307,7 @@ Source
 .. jsonschema:: ../_build_schema/components.json
    :pointer: /$defs/Source
    :collapse: assertedBy
-   :externallinks: {"type":{"url":"#source-type","text":"Source Type"}}
+   :externallinks: {"type":{"url":"#sourcetype","text":"SourceType"}}
    :allowexternalrefs:
 
 

--- a/schema/components.json
+++ b/schema/components.json
@@ -356,7 +356,7 @@
       "properties": {
         "statementPointerTarget": {
           "title": "Statement Fragment Pointer",
-          "description": "An [RFC6901 JSON Pointer](https://tools.ietf.org/html/rfc6901) describing the target fragment of the statement that this annotation applies to, starting from the root of the statement. A value of '/' indicates that the annotation applies to the whole statement.",
+          "description": "An RFC6901 JSON Pointer (https://tools.ietf.org/html/rfc6901) describing the target fragment of the statement that this annotation applies to, starting from the root of the statement. A value of '/' indicates that the annotation applies to the whole statement.",
           "type": "string"
         },
         "creationDate": {

--- a/schema/components.json
+++ b/schema/components.json
@@ -356,7 +356,7 @@
       "properties": {
         "statementPointerTarget": {
           "title": "Statement Fragment Pointer",
-          "description": "An RFC6901 JSON Pointer (https://tools.ietf.org/html/rfc6901) describing the target fragment of the statement that this annotation applies to, starting from the root of the statement. A value of '/' indicates that the annotation applies to the whole statement.",
+          "description": "An [RFC6901 JSON Pointer](https://tools.ietf.org/html/rfc6901) describing the target fragment of the statement that this annotation applies to, starting from the root of the statement. A value of '/' indicates that the annotation applies to the whole statement.",
           "type": "string"
         },
         "creationDate": {


### PR DESCRIPTION
# Overview

- What does this pull request do? Adds spaces to the subheadings in the reference page
- How can a reviewer test or examine your changes? building the docs locally and checking the page?
- Who is best placed to review it? Kadie

(Closes/Relates to) issue: #

## Translations

- [ ] New or edited strings appearing as a result of this PR will be picked up for translation
- [ ] I've notified the translation coordinator of any new strings that will need
      translating. See: https://openownership.github.io/bods-dev-handbook/translations.html

## Documentation & Release

- [ ] I've thought about how and when this needs to be released. See:
      https://openownership.github.io/bods-dev-handbook/standard_releases.html      
- [ ] I've updated the changelog, if necessary.
- [ ] I've updated [reference.rst](https://standard.openownership.org/en/latest/schema/reference.html) to reflect any changes to schema structure or naming.
- [ ] I've added or edited any other related documentation. See: https://github.com/openownership/bods-dev-handbook/blob/master/style_guide.md
