### PR TITLE
Storing warning text in one central location

### DIFF
--- a/docs/schema/changelog.rst
+++ b/docs/schema/changelog.rst
@@ -4,13 +4,7 @@
 ChangeLog
 =========
 
-.. attention:: 
-   
-    The latest is v0.3 of the Beneficial Ownership Data Standard. It includes updates to the data model and codelists as well as additional technical guidance.
-    
-    Implementers should be aware that future changes are anticipated, before a version 1.0 release. However any structural changes, or major definitional changes, will only take place following consultation, with a clear changelog provided, and with the documentation of previous versions maintained in archive form.
-
-    The schema specifies a **structure**, **fields** and **codelists** but does not yet enforce validation constraints on most fields.
+.. include:: warningbox.rst
 
 [Unreleased]
 ============

--- a/docs/schema/concepts.rst
+++ b/docs/schema/concepts.rst
@@ -3,14 +3,7 @@
 Key concepts
 ============
 
-.. attention:: 
-    
-    This is v0.3 of the Beneficial Ownership Data Standard. It includes updates to the data model and codelists as well as additional technical guidance. 
-    
-    Implementers should be aware that future changes are anticipated, before a version 1.0 release. See the :doc:`Changelog <changelog>` and `About <../about>`_ pages for more information.
-
-    **MUST** and **SHOULD** are used in the schema to denote required and recommended elements of the Standard, as defined in `RFC2119 <https://tools.ietf.org/html/rfc2119>`_.
-
+.. include:: warningbox.rst
 
 The concept of a 'statement' is at the heart of the Beneficial Ownership Data Standard. BODS data consists of a collection of ordered statements describing:
 

--- a/docs/schema/guidance/index.rst
+++ b/docs/schema/guidance/index.rst
@@ -1,13 +1,7 @@
 Technical guidance
 ==================
 
-.. attention:: 
-    
-    This is v0.3 of the Beneficial Ownership Data Standard. It includes updates to the data model and codelists as well as additional technical guidance. 
-    
-    Implementers should be aware that future changes are anticipated, before a version 1.0 release. See the :any:`Changelog <changelog>` and `About <../../about>`_ pages for more information.
-
-    **MUST** and **SHOULD** are used in the schema to denote required and recommended elements of the Standard, as defined in `RFC2119 <https://tools.ietf.org/html/rfc2119>`_.
+.. include:: /schema/warningbox.rst
 
 This section contains guidance and instruction on preparing and using BODS data. Along with the :ref:`Schema reference <schema-reference>` it comprises the core of the data schema specification.
 

--- a/docs/schema/index.rst
+++ b/docs/schema/index.rst
@@ -1,13 +1,6 @@
 Data Schema
 ===========
-
-.. attention:: 
-    
-    This is v0.3 of the Beneficial Ownership Data Standard. It includes updates to the data model and codelists as well as additional technical guidance. 
-    
-    Implementers should be aware that future changes are anticipated, before a version 1.0 release. See the :doc:`Changelog <changelog>` and `About <../about>`_ pages for more information.
-
-    **MUST** and **SHOULD** are used in the schema to denote required and recommended elements of the Standard, as defined in `RFC2119 <https://tools.ietf.org/html/rfc2119>`_.
+.. include:: warningbox.rst
 
 BODS provides a common data model for encapsulating information about the :doc:`beneficial ownership <../primer/whatisbo>` of corporate entities and related arrangements, to facilitate :doc:`sharing of information <../primer/whatisthebods>`. In particular, the :any:`data model <key-concepts>` captures direct and indirect relationships of ownership and control by entities (such as companies) by other entities (including trusts and joint shareholdings) or by natural persons. 
 

--- a/docs/schema/reference.rst
+++ b/docs/schema/reference.rst
@@ -3,14 +3,7 @@
 Schema reference
 ================
 
-.. attention:: 
-    
-    This is v0.3 of the Beneficial Ownership Data Standard. It includes updates to the data model and codelists as well as additional technical guidance. 
-    
-    Implementers should be aware that future changes are anticipated, before a version 1.0 release. See the :doc:`Changelog <changelog>` and `About <../about>`_ pages for more information.
-
-    **MUST** and **SHOULD** are used in the schema to denote required and recommended elements of the Standard, as defined in `RFC2119 <https://tools.ietf.org/html/rfc2119>`_.
-
+.. include:: warningbox.rst
 
 The following is an A - Z guide to the objects of the Data Standard's schema, plus its `codelists`_ . Details of each object's properties are provided in a table generated from the JSON schema. (For a structured view of how objects fit together in the JSON schema, use the :doc:`Schema browser <schema-browser>`.)
 

--- a/docs/schema/schema-browser.rst
+++ b/docs/schema/schema-browser.rst
@@ -3,14 +3,7 @@
 Schema browser
 ==============
 
-.. attention:: 
-    
-    This is v0.3 of the Beneficial Ownership Data Standard. It includes updates to the data model and codelists as well as additional technical guidance. 
-    
-    Implementers should be aware that future changes are anticipated, before a version 1.0 release. See the :doc:`Changelog <changelog>` and `About <../about>`_ pages for more information.
-
-    **MUST** and **SHOULD** are used in the schema to denote required and recommended elements of the Standard, as defined in `RFC2119 <https://tools.ietf.org/html/rfc2119>`_.
-
+.. include:: warningbox.rst
 
 The draft Beneficial Ownership Data Standard schema is defined using `JSON Schema 0.4 <https://json-schema.org/>`_.
 

--- a/docs/schema/warningbox.rst
+++ b/docs/schema/warningbox.rst
@@ -1,0 +1,7 @@
+.. attention:: 
+   
+   This is v0.4 of the Beneficial Ownership Data Standard. It includes updates to the data model and codelists as well as additional technical guidance.
+   
+   Implementers should be aware that future changes are anticipated, before a version 1.0 release. See the Changelog and About pages for more information.
+   
+   MUST and SHOULD are used in the schema to denote required and recommended elements of the Standard, as defined in RFC2119.


### PR DESCRIPTION
# Overview

- What does this pull request do? previously the version warning was pasted onto each page manually. This places the warning into a file warningbox.rst that is referenced by other files. This will ensure the warning is consistent across pages and makes it easier to edit the warning. 
- How can a reviewer test or examine your changes? Build the docs and check the warning is showing on the relevant pages. The warning now says '0.4' instead of '0.3' 
- Who is best placed to review it? @kd-ods 

(Closes/Relates to) issue: #

## Translations

- [ ] New or edited strings appearing as a result of this PR will be picked up for translation
- [ ] I've notified the translation coordinator of any new strings that will need
      translating. See: https://openownership.github.io/bods-dev-handbook/translations.html

## Documentation & Release

- [x] I've checked that the documentation builds without failing. See: https://github.com/openownership/data-standard#building-the-documentation-locally
- [ ] I've thought about how and when this needs to be released. See:
      https://openownership.github.io/bods-dev-handbook/standard_releases.html      
- [ ] I've updated the changelog, if necessary.
- [ ] I've updated [reference.rst](https://standard.openownership.org/en/latest/schema/reference.html) to reflect any changes to schema structure or naming.
- [ ] I've added or edited any other related documentation. See: https://github.com/openownership/bods-dev-handbook/blob/master/style_guide.md
