### PR TITLE
Entitysubtypechanges

### DIFF
--- a/examples/valid-bods-package-fi-soe.json
+++ b/examples/valid-bods-package-fi-soe.json
@@ -100,7 +100,7 @@
       "isComponent": true,
       "entityType": "stateBody",
       "entitySubtype": {
-        "generalCategory": "stateBody-governmentDepartment",
+        "generalCategory": "governmentDepartment",
         "localTerm": "ministerio"
       },
       "name": "Valtiovarainministerio",

--- a/schema/codelists/entitySubtypeCategory.csv
+++ b/schema/codelists/entitySubtypeCategory.csv
@@ -1,4 +1,6 @@
 code,title,description,technical note
-stateBody-governmentDepartment,State body > Government department,"An element of government with executive responsibilities. Terms often used to designate such a body: ministry, department, bureau or office.",
-stateBody-stateAgency,State body > State Agency,A body overseeing or administering elements of public policy. State agencies may have responsiblities which are devolved from government departments or from the state's legislative body.,
-stateBody-other,State body > Other,A type of state body unlike a government department or state agency.,
+governmentDepartment,Government department,"An element of government with executive responsibilities. Terms often used to designate such a body: ministry, department, bureau or office. This MUST be used with entityType `stateBody`.",
+stateAgency,State Agency,A body overseeing or administering elements of public policy. State agencies may have responsiblities which are devolved from government departments or from the state's legislative body. This MUST be used with entityType `stateBody`.,
+other,Other,Any other type of entity.,
+trust,Trust,A trust or trust like arrangement. An arrangement where a settlor transfers ownership of assets to trustees to control for the benefit of beneficiaries. This MUST be used with entityType arrangement or legalEntity,
+nomination,Nomination,An agreement where a nominator instructs a nominee to act on their behalf in a specified capacity. This MUST be used with entityType arrangement.,

--- a/schema/entity-record.json
+++ b/schema/entity-record.json
@@ -254,5 +254,26 @@
         }
       }
     }
+  },
+  "if":{
+    "properties":{
+      "entitySubtype":{
+        "properties":{
+          "generalCategory":{
+            "const":"trust"
+          }
+        }
+      }
+    }
+  },
+  "then":{
+    "properties":{
+      "entityType":{
+        "enum":[
+          "arrangement",
+          "legalEntity"
+        ]
+      }
+    }
   }
 }

--- a/schema/entity-record.json
+++ b/schema/entity-record.json
@@ -112,9 +112,11 @@
           "description": "The general category into which the entity fits. The category classification MUST align with the `entityType` classification.",
           "codelist": "entitySubtypeCategory.csv",
           "enum": [
-            "stateBody-governmentDepartment",
-            "stateBody-stateAgency",
-            "stateBody-other"
+            "governmentDepartment",
+            "stateAgency",
+            "other",
+            "trust",
+            "nomination"
           ],
           "openCodelist": false
         },

--- a/schema/entity-record.json
+++ b/schema/entity-record.json
@@ -254,26 +254,5 @@
         }
       }
     }
-  },
-  "if":{
-    "properties":{
-      "entitySubtype":{
-        "properties":{
-          "generalCategory":{
-            "const":"trust"
-          }
-        }
-      }
-    }
-  },
-  "then":{
-    "properties":{
-      "entityType":{
-        "enum":[
-          "arrangement",
-          "legalEntity"
-        ]
-      }
-    }
   }
 }


### PR DESCRIPTION
# Overview

- What does this pull request do? updates the codelist and example data for entitySubtype - general category to remove the 'stateBody' prefix and add in 'trust' and 'nomination' 
- How can a reviewer test or examine your changes?
- Who is best placed to review it?

(Closes/Relates to) issue: #518 #519 #520 

## Translations

- [ ] New or edited strings appearing as a result of this PR will be picked up for translation
- [ ] I've notified the translation coordinator of any new strings that will need
      translating. See: https://openownership.github.io/bods-dev-handbook/translations.html

## Documentation & Release

- [ ] I've checked that the documentation builds without failing. See: https://github.com/openownership/data-standard#building-the-documentation-locally
- [ ] I've thought about how and when this needs to be released. See:
      https://openownership.github.io/bods-dev-handbook/standard_releases.html      
- [ ] I've updated the changelog, if necessary.
- [ ] I've updated [reference.rst](https://standard.openownership.org/en/latest/schema/reference.html) to reflect any changes to schema structure or naming.
- [ ] I've added or edited any other related documentation. See: https://github.com/openownership/bods-dev-handbook/blob/master/style_guide.md
