### PR TITLE
Add statementDate as required

### DIFF
--- a/examples/4a-simple-pep-declaration.json
+++ b/examples/4a-simple-pep-declaration.json
@@ -2,6 +2,7 @@
   {
     "statementId": "41fd9f6c-ad31-4209-9ed8-1ec46cb0cae5",
     "declarationSubject": "841083ba86e3",
+    "statementDate": "2019-06-07",
     "publicationDetails": {
       "publicationDate": "2019-06-07",
       "bodsVersion": "0.4",
@@ -28,6 +29,7 @@
   {
     "statementId": "a40f766e-0c33-4e34-b9d4-80e39aa99496",
     "declarationSubject": "841083ba86e3",
+    "statementDate": "2019-06-07",
     "publicationDetails": {
       "publicationDate": "2019-06-07",
       "bodsVersion": "0.4",
@@ -55,6 +57,7 @@
   {
     "statementId": "ef7e0d77-1e2b-44c0-a91c-7670db09d2a4",
     "declarationSubject": "841083ba86e3",
+    "statementDate": "2019-06-07",
     "publicationDetails": {
       "publicationDate": "2019-06-07",
       "bodsVersion": "0.4",

--- a/schema/statement.json
+++ b/schema/statement.json
@@ -23,7 +23,7 @@
           },
           "statementDate": {
             "title": "Statement date",
-            "description": "The date (optionally including time) on which this statement was declared by the source.",
+            "description": "The date (optionally including time) on which this statement was declared by the source, in YYYY-MM-DDTHH:MM:SS or YYYY-MM-DD format.",
             "type": "string",
             "anyOf": [
               {
@@ -214,7 +214,8 @@
           "declarationSubject",
           "recordId",
           "recordType",
-          "recordDetails"
+          "recordDetails",
+          "statementDate"
         ]
       },
     "Annotation": {

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -169,6 +169,7 @@ def get_valid_data():
         {
             "statementId": "abcdefgkdddddddddddddddddddddddshdkjfkjdkjf",
             "declarationSubject": "xyz",
+            "statementDate": "2017-11-18",
             "recordId": "123",
             "recordType": "entity",
             "recordDetails": {

--- a/tests/data/invalid-statements/entity_statementDate_format.json
+++ b/tests/data/invalid-statements/entity_statementDate_format.json
@@ -1,0 +1,13 @@
+[
+    {
+        "statementId": "2f7bf9370f1254068e5e946df067d07d",
+        "declarationSubject": "xyz",
+        "statementDate": "2020",
+        "recordId": "123",
+        "recordType": "entity",
+        "recordDetails": {
+            "entityType": "registeredEntity",
+            "isComponent": false
+        }
+    }
+]

--- a/tests/data/invalid-statements/entity_statementDate_missing.json
+++ b/tests/data/invalid-statements/entity_statementDate_missing.json
@@ -1,0 +1,12 @@
+[
+    {
+        "statementId": "2f7bf9370f1254068e5e946df067d07d",
+        "declarationSubject": "xyz",
+        "recordId": "123",
+        "recordType": "entity",
+        "recordDetails": {
+            "entityType": "registeredEntity",
+            "isComponent": false
+        }
+    }
+]

--- a/tests/data/invalid-statements/inv_entity_address_country_no_name.json
+++ b/tests/data/invalid-statements/inv_entity_address_country_no_name.json
@@ -2,6 +2,7 @@
     {
         "statementId": "2f7bf9370f1254068e5e946df067d07d",
         "declarationSubject": "xyz",
+        "statementDate": "2017-11-18",
         "recordId": "123",
         "recordType": "entity",
         "recordDetails": {

--- a/tests/data/invalid-statements/inv_entity_address_country_no_object.json
+++ b/tests/data/invalid-statements/inv_entity_address_country_no_object.json
@@ -2,6 +2,7 @@
     {
         "statementId": "2f7bf9370f1254068e5e946df067d07d",
         "declarationSubject": "xyz",
+        "statementDate": "2017-11-18",
         "recordId": "123",
         "recordType": "entity",
         "recordDetails": {

--- a/tests/data/valid-statements/entity_address_country.json
+++ b/tests/data/valid-statements/entity_address_country.json
@@ -2,6 +2,7 @@
     {
         "statementId": "2f7bf9370f1254068e5e946df067d07d",
         "declarationSubject": "xyz",
+        "statementDate": "2017-11-18",
         "recordId": "123",
         "recordType": "entity",
         "recordDetails": {

--- a/tests/data/valid-statements/entity_address_country_no_code.json
+++ b/tests/data/valid-statements/entity_address_country_no_code.json
@@ -2,6 +2,7 @@
     {
         "statementId": "2f7bf9370f1254068e5e946df067d07d",
         "declarationSubject": "xyz",
+        "statementDate": "2017-11-18",
         "recordId": "123",
         "recordType": "entity",
         "recordDetails": {

--- a/tests/data/valid-statements/entity_statementDate.json
+++ b/tests/data/valid-statements/entity_statementDate.json
@@ -1,0 +1,13 @@
+[
+    {
+        "statementId": "2f7bf9370f1254068e5e946df067d07d",
+        "declarationSubject": "xyz",
+        "statementDate": "2017-11-18",
+        "recordId": "123",
+        "recordType": "entity",
+        "recordDetails": {
+            "entityType": "registeredEntity",
+            "isComponent": false
+        }
+    }
+]

--- a/tests/data/valid-statements/entity_statementDate_time.json
+++ b/tests/data/valid-statements/entity_statementDate_time.json
@@ -1,0 +1,13 @@
+[
+    {
+        "statementId": "2f7bf9370f1254068e5e946df067d07d",
+        "declarationSubject": "xyz",
+        "statementDate": "2020-09-11T16:30:23Z",
+        "recordId": "123",
+        "recordType": "entity",
+        "recordDetails": {
+            "entityType": "registeredEntity",
+            "isComponent": false
+        }
+    }
+]

--- a/tests/data/valid-statements/fermentcat_entity_address_address.json
+++ b/tests/data/valid-statements/fermentcat_entity_address_address.json
@@ -4,6 +4,7 @@
         "recordId": "ent-93c75c87ab28f889",
         "recordType": "entity",
         "declarationSubject": "ent-93c75c87ab28f889",
+        "statementDate": "2017-11-18",
         "recordDetails": {
             "isComponent": false,
             "entityType": "registeredEntity",

--- a/tests/data/valid-statements/fermentcat_entity_address_country.json
+++ b/tests/data/valid-statements/fermentcat_entity_address_country.json
@@ -4,6 +4,7 @@
         "recordId": "ent-93c75c87ab28f889",
         "recordType": "entity",
         "declarationSubject": "ent-93c75c87ab28f889",
+        "statementDate": "2017-11-18",
         "recordDetails": {
             "isComponent": false,
             "entityType": "registeredEntity",

--- a/tests/data/valid-statements/fermentcat_entity_address_postcode.json
+++ b/tests/data/valid-statements/fermentcat_entity_address_postcode.json
@@ -4,6 +4,7 @@
         "recordId": "ent-93c75c87ab28f889",
         "recordType": "entity",
         "declarationSubject": "ent-93c75c87ab28f889",
+        "statementDate": "2017-11-18",
         "recordDetails": {
             "isComponent": false,
             "entityType": "registeredEntity",

--- a/tests/data/valid-statements/fermentcat_entity_address_type.json
+++ b/tests/data/valid-statements/fermentcat_entity_address_type.json
@@ -4,6 +4,7 @@
         "recordId": "ent-93c75c87ab28f889",
         "recordType": "entity",
         "declarationSubject": "ent-93c75c87ab28f889",
+        "statementDate": "2017-11-18",
         "recordDetails": {
             "isComponent": false,
             "entityType": "registeredEntity",

--- a/tests/data/valid-statements/fermentcat_entity_founding_date.json
+++ b/tests/data/valid-statements/fermentcat_entity_founding_date.json
@@ -4,6 +4,7 @@
         "recordId": "ent-93c75c87ab28f889",
         "recordType": "entity",
         "declarationSubject": "ent-93c75c87ab28f889",
+        "statementDate": "2017-11-18",
         "recordDetails": {
             "isComponent": false,
             "entityType": "registeredEntity",

--- a/tests/data/valid-statements/fermentcat_entity_identifiers_id.json
+++ b/tests/data/valid-statements/fermentcat_entity_identifiers_id.json
@@ -4,6 +4,7 @@
         "recordId": "ent-93c75c87ab28f889",
         "recordType": "entity",
         "declarationSubject": "ent-93c75c87ab28f889",
+        "statementDate": "2017-11-18",
         "recordDetails": {
             "isComponent": false,
             "entityType": "registeredEntity",

--- a/tests/data/valid-statements/fermentcat_entity_identifiers_scheme.json
+++ b/tests/data/valid-statements/fermentcat_entity_identifiers_scheme.json
@@ -4,6 +4,7 @@
         "recordId": "ent-93c75c87ab28f889",
         "recordType": "entity",
         "declarationSubject": "ent-93c75c87ab28f889",
+        "statementDate": "2017-11-18",
         "recordDetails": {
             "isComponent": false,
             "entityType": "registeredEntity",

--- a/tests/data/valid-statements/fermentcat_entity_identifiers_scheme_name.json
+++ b/tests/data/valid-statements/fermentcat_entity_identifiers_scheme_name.json
@@ -4,6 +4,7 @@
         "recordId": "ent-93c75c87ab28f889",
         "recordType": "entity",
         "declarationSubject": "ent-93c75c87ab28f889",
+        "statementDate": "2017-11-18",
         "recordDetails": {
             "isComponent": false,
             "entityType": "registeredEntity",

--- a/tests/data/valid-statements/fermentcat_entity_jurisdiction_code.json
+++ b/tests/data/valid-statements/fermentcat_entity_jurisdiction_code.json
@@ -4,6 +4,7 @@
         "recordId": "ent-93c75c87ab28f889",
         "recordType": "entity",
         "declarationSubject": "ent-93c75c87ab28f889",
+        "statementDate": "2017-11-18",
         "recordDetails": {
             "isComponent": false,
             "entityType": "registeredEntity",

--- a/tests/data/valid-statements/fermentcat_entity_jurisdiction_name.json
+++ b/tests/data/valid-statements/fermentcat_entity_jurisdiction_name.json
@@ -4,6 +4,7 @@
         "recordId": "ent-93c75c87ab28f889",
         "recordType": "entity",
         "declarationSubject": "ent-93c75c87ab28f889",
+        "statementDate": "2017-11-18",
         "recordDetails": {
             "isComponent": false,
             "entityType": "registeredEntity",

--- a/tests/data/valid-statements/fermentcat_entity_name.json
+++ b/tests/data/valid-statements/fermentcat_entity_name.json
@@ -4,6 +4,7 @@
         "recordId": "ent-93c75c87ab28f889",
         "recordType": "entity",
         "declarationSubject": "ent-93c75c87ab28f889",
+        "statementDate": "2017-11-18",
         "recordDetails": {
             "isComponent": false,
             "entityType": "registeredEntity",

--- a/tests/data/valid-statements/fermentcat_entity_public_listing.json
+++ b/tests/data/valid-statements/fermentcat_entity_public_listing.json
@@ -4,6 +4,7 @@
         "recordId": "ent-93c75c87ab28f889",
         "recordType": "entity",
         "declarationSubject": "ent-93c75c87ab28f889",
+        "statementDate": "2017-11-18",
         "recordDetails": {
             "isComponent": false,
             "entityType": "registeredEntity",

--- a/tests/data/valid-statements/fermentcat_person_birth_date.json
+++ b/tests/data/valid-statements/fermentcat_person_birth_date.json
@@ -4,6 +4,7 @@
         "recordId": "per-5faa4103dee78621",
         "recordType": "person",
         "declarationSubject": "ent-93c75c87ab28f889",
+        "statementDate": "2017-11-18",
         "recordDetails": {
             "isComponent": false,
             "personType": "knownPerson",

--- a/tests/data/valid-statements/fermentcat_person_identifiers_id.json
+++ b/tests/data/valid-statements/fermentcat_person_identifiers_id.json
@@ -4,6 +4,7 @@
         "recordId": "per-5faa4103dee78621",
         "recordType": "person",
         "declarationSubject": "ent-93c75c87ab28f889",
+        "statementDate": "2017-11-18",
         "recordDetails": {
             "isComponent": false,
             "personType": "knownPerson",

--- a/tests/data/valid-statements/fermentcat_person_identifiers_scheme.json
+++ b/tests/data/valid-statements/fermentcat_person_identifiers_scheme.json
@@ -4,6 +4,7 @@
         "recordId": "per-5faa4103dee78621",
         "recordType": "person",
         "declarationSubject": "ent-93c75c87ab28f889",
+        "statementDate": "2017-11-18",
         "recordDetails": {
             "isComponent": false,
             "personType": "knownPerson",

--- a/tests/data/valid-statements/fermentcat_person_identifiers_scheme_name.json
+++ b/tests/data/valid-statements/fermentcat_person_identifiers_scheme_name.json
@@ -4,6 +4,7 @@
         "recordId": "per-5faa4103dee78621",
         "recordType": "person",
         "declarationSubject": "ent-93c75c87ab28f889",
+        "statementDate": "2017-11-18",
         "recordDetails": {
             "isComponent": false,
             "personType": "knownPerson",

--- a/tests/data/valid-statements/fermentcat_person_names_family_name.json
+++ b/tests/data/valid-statements/fermentcat_person_names_family_name.json
@@ -4,6 +4,7 @@
         "recordId": "per-5faa4103dee78621",
         "recordType": "person",
         "declarationSubject": "ent-93c75c87ab28f889",
+        "statementDate": "2017-11-18",
         "recordDetails": {
             "isComponent": false,
             "personType": "knownPerson",

--- a/tests/data/valid-statements/fermentcat_person_names_full_name.json
+++ b/tests/data/valid-statements/fermentcat_person_names_full_name.json
@@ -4,6 +4,7 @@
         "recordId": "per-5faa4103dee78621",
         "recordType": "person",
         "declarationSubject": "ent-93c75c87ab28f889",
+        "statementDate": "2017-11-18",
         "recordDetails": {
             "isComponent": false,
             "personType": "knownPerson",

--- a/tests/data/valid-statements/fermentcat_person_names_given_name.json
+++ b/tests/data/valid-statements/fermentcat_person_names_given_name.json
@@ -4,6 +4,7 @@
         "recordId": "per-5faa4103dee78621",
         "recordType": "person",
         "declarationSubject": "ent-93c75c87ab28f889",
+        "statementDate": "2017-11-18",
         "recordDetails": {
             "isComponent": false,
             "personType": "knownPerson",

--- a/tests/data/valid-statements/fermentcat_person_names_type.json
+++ b/tests/data/valid-statements/fermentcat_person_names_type.json
@@ -4,6 +4,7 @@
         "recordId": "per-5faa4103dee78621",
         "recordType": "person",
         "declarationSubject": "ent-93c75c87ab28f889",
+        "statementDate": "2017-11-18",
         "recordDetails": {
             "isComponent": false,
             "personType": "knownPerson",

--- a/tests/data/valid-statements/fermentcat_person_nationalities_code.json
+++ b/tests/data/valid-statements/fermentcat_person_nationalities_code.json
@@ -4,6 +4,7 @@
         "recordId": "per-5faa4103dee78621",
         "recordType": "person",
         "declarationSubject": "ent-93c75c87ab28f889",
+        "statementDate": "2017-11-18",
         "recordDetails": {
             "isComponent": false,
             "personType": "knownPerson",

--- a/tests/data/valid-statements/fermentcat_person_nationalities_name.json
+++ b/tests/data/valid-statements/fermentcat_person_nationalities_name.json
@@ -4,6 +4,7 @@
         "recordId": "per-5faa4103dee78621",
         "recordType": "person",
         "declarationSubject": "ent-93c75c87ab28f889",
+        "statementDate": "2017-11-18",
         "recordDetails": {
             "isComponent": false,
             "personType": "knownPerson",

--- a/tests/data/valid-statements/fermentcat_publication_details_date.json
+++ b/tests/data/valid-statements/fermentcat_publication_details_date.json
@@ -9,6 +9,7 @@
         "recordId": "ent-93c75c87ab28f889",
         "recordType": "entity",
         "declarationSubject": "ent-93c75c87ab28f889",
+        "statementDate": "2017-11-18",
         "recordDetails": {
             "isComponent": false,
             "entityType": "registeredEntity"

--- a/tests/data/valid-statements/fermentcat_publication_details_license.json
+++ b/tests/data/valid-statements/fermentcat_publication_details_license.json
@@ -10,6 +10,7 @@
         "recordId": "ent-93c75c87ab28f889",
         "recordType": "entity",
         "declarationSubject": "ent-93c75c87ab28f889",
+        "statementDate": "2017-11-18",
         "recordDetails": {
             "isComponent": false,
             "entityType": "registeredEntity"

--- a/tests/data/valid-statements/fermentcat_publication_details_publisher_name.json
+++ b/tests/data/valid-statements/fermentcat_publication_details_publisher_name.json
@@ -11,6 +11,7 @@
         "recordId": "ent-93c75c87ab28f889",
         "recordType": "entity",
         "declarationSubject": "ent-93c75c87ab28f889",
+        "statementDate": "2017-11-18",
         "recordDetails": {
             "isComponent": false,
             "entityType": "registeredEntity"

--- a/tests/data/valid-statements/fermentcat_publication_details_version.json
+++ b/tests/data/valid-statements/fermentcat_publication_details_version.json
@@ -9,6 +9,7 @@
         "recordId": "ent-93c75c87ab28f889",
         "recordType": "entity",
         "declarationSubject": "ent-93c75c87ab28f889",
+        "statementDate": "2017-11-18",
         "recordDetails": {
             "isComponent": false,
             "entityType": "registeredEntity"

--- a/tests/data/valid-statements/fermentcat_record_status.json
+++ b/tests/data/valid-statements/fermentcat_record_status.json
@@ -5,6 +5,7 @@
         "recordType": "person",
         "recordStatus": "new",
         "declarationSubject": "ent-93c75c87ab28f889",
+        "statementDate": "2017-11-18",
         "recordDetails": {
             "isComponent": false,
             "personType": "knownPerson"

--- a/tests/data/valid-statements/fermentcat_relationship_interested_party.json
+++ b/tests/data/valid-statements/fermentcat_relationship_interested_party.json
@@ -4,6 +4,7 @@
         "recordId": "rel-b05e7c91e0a04e4f",
         "recordType": "relationship",
         "declarationSubject": "ent-93c75c87ab28f889",
+        "statementDate": "2017-11-18",
         "recordDetails": {
             "isComponent": false,
             "subject": "ent-93c75c87ab28f889",

--- a/tests/data/valid-statements/fermentcat_relationship_interests_beneficial_ownership_or_control.json
+++ b/tests/data/valid-statements/fermentcat_relationship_interests_beneficial_ownership_or_control.json
@@ -4,6 +4,7 @@
         "recordId": "rel-b05e7c91e0a04e4f",
         "recordType": "relationship",
         "declarationSubject": "ent-93c75c87ab28f889",
+        "statementDate": "2017-11-18",
         "recordDetails": {
             "isComponent": false,
             "subject": "ent-93c75c87ab28f889",

--- a/tests/data/valid-statements/fermentcat_relationship_interests_direct_or_indirect.json
+++ b/tests/data/valid-statements/fermentcat_relationship_interests_direct_or_indirect.json
@@ -4,6 +4,7 @@
         "recordId": "rel-b05e7c91e0a04e4f",
         "recordType": "relationship",
         "declarationSubject": "ent-93c75c87ab28f889",
+        "statementDate": "2017-11-18",
         "recordDetails": {
             "isComponent": false,
             "subject": "ent-93c75c87ab28f889",

--- a/tests/data/valid-statements/fermentcat_relationship_interests_share.json
+++ b/tests/data/valid-statements/fermentcat_relationship_interests_share.json
@@ -4,6 +4,7 @@
         "recordId": "rel-b05e7c91e0a04e4f",
         "recordType": "relationship",
         "declarationSubject": "ent-93c75c87ab28f889",
+        "statementDate": "2017-11-18",
         "recordDetails": {
             "isComponent": false,
             "subject": "ent-93c75c87ab28f889",

--- a/tests/data/valid-statements/fermentcat_relationship_interests_start_date.json
+++ b/tests/data/valid-statements/fermentcat_relationship_interests_start_date.json
@@ -4,6 +4,7 @@
         "recordId": "rel-b05e7c91e0a04e4f",
         "recordType": "relationship",
         "declarationSubject": "ent-93c75c87ab28f889",
+        "statementDate": "2017-11-18",
         "recordDetails": {
             "isComponent": false,
             "subject": "ent-93c75c87ab28f889",

--- a/tests/data/valid-statements/fermentcat_relationship_interests_type.json
+++ b/tests/data/valid-statements/fermentcat_relationship_interests_type.json
@@ -4,6 +4,7 @@
         "recordId": "rel-b05e7c91e0a04e4f",
         "recordType": "relationship",
         "declarationSubject": "ent-93c75c87ab28f889",
+        "statementDate": "2017-11-18",
         "recordDetails": {
             "isComponent": false,
             "subject": "ent-93c75c87ab28f889",

--- a/tests/data/valid-statements/fermentcat_relationship_subject.json
+++ b/tests/data/valid-statements/fermentcat_relationship_subject.json
@@ -4,6 +4,7 @@
         "recordId": "rel-b05e7c91e0a04e4f",
         "recordType": "relationship",
         "declarationSubject": "ent-93c75c87ab28f889",
+        "statementDate": "2017-11-18",
         "recordDetails": {
             "isComponent": false,
             "subject": "ent-93c75c87ab28f889",

--- a/tests/data/valid-statements/fermentcat_source.json
+++ b/tests/data/valid-statements/fermentcat_source.json
@@ -4,6 +4,7 @@
         "recordId": "ent-93c75c87ab28f889",
         "recordType": "entity",
         "declarationSubject": "ent-93c75c87ab28f889",
+        "statementDate": "2017-11-18",
         "source": {
             "assertedBy": [
                 {


### PR DESCRIPTION
# Overview

- What does this pull request do?
 
-- Adds statementDate as required to schema
-- Updates statementDate description 
-- Updates existing example files to include statementDate
-- Creates new valid/invalid files for statementDate

- How can a reviewer test or examine your changes?

- Who is best placed to review it?

@kd-ods or @kathryn-ods 

(Closes/Relates to) issue: #523

## Translations

- [ ] New or edited strings appearing as a result of this PR will be picked up for translation
- [ ] I've notified the translation coordinator of any new strings that will need
      translating. See: https://openownership.github.io/bods-dev-handbook/translations.html

## Documentation & Release

- [ ] I've checked that the documentation builds without failing. See: https://github.com/openownership/data-standard#building-the-documentation-locally
- [ ] I've thought about how and when this needs to be released. See:
      https://openownership.github.io/bods-dev-handbook/standard_releases.html      
- [ ] I've updated the changelog, if necessary.
- [ ] I've updated [reference.rst](https://standard.openownership.org/en/latest/schema/reference.html) to reflect any changes to schema structure or naming.
- [ ] I've added or edited any other related documentation. See: https://github.com/openownership/bods-dev-handbook/blob/master/style_guide.md
