### PR TITLE
Update error message in test_schema.py to point to json validation failure

### DIFF
--- a/tests/test_schema.py
+++ b/tests/test_schema.py
@@ -44,7 +44,8 @@ def test_schemas_loaded():
     schemas_from_file = get_schema_paths()
     assert len(schemas_from_file) == len(
         schemas
-    ), "Schema found on disc that is either not valid JSON or not being tested.\nPlease fix the JSON or update the schemas variable in test_schema.py."
+    ), ("Schema found on disc that is either not valid JSON or not being tested.\n"
+        "Please fix the JSON or update the schemas variable in test_schema.py.")
 
 
 @pytest.mark.parametrize("schema_from_registry", schemas, indirect=True)

--- a/tests/test_schema.py
+++ b/tests/test_schema.py
@@ -44,7 +44,7 @@ def test_schemas_loaded():
     schemas_from_file = get_schema_paths()
     assert len(schemas_from_file) == len(
         schemas
-    ), "Schema found on disc that is not being tested.\nPlease update the schemas variable in test_schema.py."
+    ), "Schema found on disc that is either not valid JSON or not being tested.\nPlease fix the JSON or update the schemas variable in test_schema.py."
 
 
 @pytest.mark.parametrize("schema_from_registry", schemas, indirect=True)


### PR DESCRIPTION
# Overview

- What does this pull request do?

Edits the test_schemas_loaded() error message to suggest the other reason why this test might fail. (As I discovered when I left some quotation marks in a schema description unescaped and caused half of all the tests to fail!)

(We could have a dedicated test to check that each of the schema files is valid json, but that's probably overkill.)

- How can a reviewer test or examine your changes?

Eyeball and run pytest.

- Who is best placed to review it?

@rhiaro 

Closes #

## Translations

n/a

## Documentation & Release

n/a
