### PR TITLE
fixing reference to source so docs build

### DIFF
--- a/docs/schema/reference.rst
+++ b/docs/schema/reference.rst
@@ -172,7 +172,7 @@ Share
 Source
 ------
 
-.. json-value:: ../_build_schema/statement.json
+.. json-value:: ../_build_schema/components.json
    :pointer: /$defs/Source/description
 
 


### PR DESCRIPTION
# Overview

- What does this pull request do? updates the target pointer on the reference page to reflect source moving to components 
- How can a reviewer test or examine your changes? check the docs build without an error 
- Who is best placed to review it?

Closes #

## Translations

- [ ] New or edited strings appearing as a result of this PR will be picked up for translation
- [ ] I've notified the translation coordinator of any new strings that will need
      translating. See: https://openownership.github.io/bods-dev-handbook/translations.html

## Documentation & Release

- [ ] I've checked that the documentation builds without failing. See: https://github.com/openownership/data-standard#building-the-documentation-locally
- [ ] I've thought about how and when this needs to be released. See:
      https://openownership.github.io/bods-dev-handbook/standard_releases.html      
- [ ] I've updated the changelog, if necessary.
- [ ] I've updated [reference.rst](https://standard.openownership.org/en/latest/schema/reference.html) to reflect any changes to schema structure or naming.
- [ ] I've added or edited any other related documentation. See: https://github.com/openownership/bods-dev-handbook/blob/master/style_guide.md
