### PR TITLE
moving format inside the bracket on companyFilingsURLs

### DIFF
--- a/schema/entity-record.json
+++ b/schema/entity-record.json
@@ -180,9 +180,9 @@
           "title": "Company Filings URLs",
           "description": "URL or URLs where regulatory filings related to major holdings can be retrieved. URLs may point to pages maintained by regulatory bodies, stock exchanges or by the company itself.",
           "items": {
-            "type": "string"
-          },
-          "format": "uri"
+            "type": "string",
+            "format": "uri"
+          }
         },
         "securitiesListings": {
           "type": "array",


### PR DESCRIPTION
# Overview

- What does this pull request do? Currently invalid test data for 'companyFilingsURLs is an array of uri format strings' is passing as valid when using a string that is not URI format. When you move format inside items it validates as expected. 
- How can a reviewer test or examine your changes?
- Who is best placed to review it?

Closes #

## Translations

- [ ] New or edited strings appearing as a result of this PR will be picked up for translation
- [ ] I've notified the translation coordinator of any new strings that will need
      translating. See: https://openownership.github.io/bods-dev-handbook/translations.html

## Documentation & Release

- [ ] I've checked that the documentation builds without failing. See: https://github.com/openownership/data-standard#building-the-documentation-locally
- [ ] I've thought about how and when this needs to be released. See:
      https://openownership.github.io/bods-dev-handbook/standard_releases.html      
- [ ] I've updated the changelog, if necessary.
- [ ] I've updated [reference.rst](https://standard.openownership.org/en/latest/schema/reference.html) to reflect any changes to schema structure or naming.
- [ ] I've added or edited any other related documentation. See: https://github.com/openownership/bods-dev-handbook/blob/master/style_guide.md
