### PR TITLE
fixing error message Sphinx 8 will drop support for representing path…

### DIFF
--- a/docs/conf.py
+++ b/docs/conf.py
@@ -233,8 +233,8 @@ redirect_files = [
 def copy_legacy_redirects(app, docname):  # Sphinx expects two arguments
     if app.builder.name == 'html' or app.builder.name == 'readthedocs':
         for html_src_path in redirect_files:
-            target_path = app.outdir + '/' + html_src_path
-            src_path = app.srcdir + '/' + html_src_path
+            target_path = os.path.join(app.outdir, html_src_path)
+            src_path = os.path.join(app.srcdir, html_src_path)
             if os.path.isfile(src_path):
                 copyfile(src_path, target_path)
 


### PR DESCRIPTION
…s as strings. Use pathlib.Path or os.fspath instead.

# Overview

- What does this pull request do? fixes error message. Fix pinched from https://lore.kernel.org/all/08f17a6c-8077-492a-bcd2-373a1d2ab831@claudiocambra.com/T/
- How can a reviewer test or examine your changes?
- Who is best placed to review it?

Closes #677 

## Translations

- [ ] New or edited strings appearing as a result of this PR will be picked up for translation
- [ ] I've notified the translation coordinator of any new strings that will need
      translating. See: https://openownership.github.io/bods-dev-handbook/translations.html

## Documentation & Release

- [ ] I've checked that the documentation builds without failing. See: https://github.com/openownership/data-standard#building-the-documentation-locally
- [ ] I've thought about how and when this needs to be released. See:
      https://openownership.github.io/bods-dev-handbook/standard_releases.html      
- [ ] I've updated the changelog, if necessary.
- [ ] I've updated [reference.rst](https://standard.openownership.org/en/latest/schema/reference.html) to reflect any changes to schema structure or naming.
- [ ] I've added or edited any other related documentation. See: https://github.com/openownership/bods-dev-handbook/blob/master/style_guide.md
