### PR TITLE
docs/conf.py: Update to handle RTD changes

### DIFF
--- a/.github/workflows/docsbuild.yml
+++ b/.github/workflows/docsbuild.yml
@@ -5,18 +5,14 @@ jobs:
   linkcheck:
     runs-on: ubuntu-latest
     steps:
-    - uses: actions/checkout@v2
+    - uses: actions/checkout@v6
       with:
         submodules: 'true'
     - name: Setup python
-      uses: actions/setup-python@v2
+      uses: actions/setup-python@v6
       with:
-        python-version: 3.9
+        python-version: 3.11
         architecture: x64
-    - uses: actions/cache@v1
-      with:
-        path: ~/.cache/pip
-        key: ${{ runner.os }}-pip-${{ hashFiles('**/requirements.txt') }}
     - run: pip install -r requirements.txt
     - run: cd ./docs/ && make dirhtml
     - run: cd ./docs/ && make linkcheck

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -8,19 +8,12 @@ jobs:
       matrix:
         python-version: [ '3.11']
     steps:
-    - uses: actions/checkout@v2
+    - uses: actions/checkout@v6
     - name: Setup python
-      uses: actions/setup-python@v2
+      uses: actions/setup-python@v6
       with:
         python-version: ${{ matrix.python-version }}
         architecture: x64
-    - uses: actions/cache@v1
-      with:
-        path: ~/.cache/pip
-        key: ${{ runner.os }}-pip-${{ hashFiles('**/requirements_dev.txt') }}-${{ matrix.python-version }}
-        restore-keys: |
-          ${{ runner.os }}-pip-
-
     - name: Install requirements_test.txt
       run: pip install -r requirements_test.txt
     - name: flake8

--- a/docs/conf.py
+++ b/docs/conf.py
@@ -36,6 +36,17 @@ import ocds_babel.translate as translate
 # import oods.pygments
 import oods.sphinxtheme
 
+# -- Read the Docs --------------------------------------------------------
+
+# Define the canonical URL if you are using a custom domain on Read the Docs
+html_baseurl = os.environ.get("READTHEDOCS_CANONICAL_URL", "")
+
+# Tell Jinja2 templates the build is running on Read the Docs
+if os.environ.get("READTHEDOCS", "") == "True":
+    if "html_context" not in globals():
+        html_context = {}
+    html_context["READTHEDOCS"] = True
+
 # -- General configuration ------------------------------------------------
 
 html_context = {'bods_schema_version': '0.4'}


### PR DESCRIPTION
Read The Docs has [changed](https://about.readthedocs.com/blog/2024/07/addons-by-default/) the way it works. Rather than automatically, and silently, messing with sphinx config files to add certain things, it expects certain changes to the config file for everything to work.


# Overview

**What does this pull request do?**

Updates docs/conf.py

**How can a reviewer test or examine your changes?**

Check the build is working at https://standard.openownership.org/en/rtd_config_update/standard/modelling/index.html

**Who is best placed to review it?**

Ed

Closes #

## Translations

n/a

## Documentation & Release

- [ ] I've checked that the documentation builds without failing. [See the Handbook](https://github.com/openownership/data-standard#building-the-documentation-locally)
- n/a I've thought about how and when this needs to be released. [See the Handbook](https://openownership.github.io/bods-dev-handbook/standard_releases.html)      
- n/a I've updated the changelog, if necessary. [See the Handbook](https://openownership.github.io/bods-dev-handbook/standard_releases.html#changelog)
- n/a I've updated [reference.rst](https://standard.openownership.org/en/latest/schema/reference.html) to reflect any changes to schema structure or naming.
- n/a I've updated the [BODS validation specification](https://docs.google.com/spreadsheets/d/1KTHGSb_ZkCLB9QpjQ891Y_RxvlBJHFEITjOxptaOTAQ/edit?usp=sharing) if necessary. [See the Handbook](https://openownership.github.io/bods-dev-handbook/data_validation.html)
- n/a I've added or edited any other related documentation. [See the Handbook](https://github.com/openownership/bods-dev-handbook/blob/master/style_guide.md)
