### PR TITLE
Fix typo in subjectUnableToConfirmOrIdentifyBeneficialOwner description

### DIFF
--- a/schema/codelists/unspecifiedReason.csv
+++ b/schema/codelists/unspecifiedReason.csv
@@ -1,6 +1,6 @@
 code,title,description
 noBeneficialOwners,No beneficial owners,There are no beneficial owners who need to disclose ownership according to the rules under which this statement is made.
-subjectUnableToConfirmOrIdentifyBeneficialOwner,Subject unable to confirm or identify beneficial owner,"The subject of this Relationship Statement has, as the disclosing party, been unwilling or unable to confirm the existence identify a beneficial owner."
+subjectUnableToConfirmOrIdentifyBeneficialOwner,Subject unable to confirm or identify beneficial owner,"The subject of this Relationship Statement has, as the disclosing party, been unwilling or unable to confirm the existence of or identify a beneficial owner."
 interestedPartyHasNotProvidedInformation,Interested party has not provided information,The interested party in this Relationship Statement has not provided enough information to identify or confirm the identity of the beneficial owner.
 subjectExemptFromDisclosure,Subject exempt from disclosure,The subject of this Relationship Statement is not required to disclose its beneficial owner.
 interestedPartyExemptFromDisclosure,Interested party exempt from disclosure,The interested party in this Relationship Statement is exempt from having their identity disclosed.


### PR DESCRIPTION
## Summary

Fixes #730.

The description of the `subjectUnableToConfirmOrIdentifyBeneficialOwner` code in `schema/codelists/unspecifiedReason.csv` was missing words, making the sentence ungrammatical:

> ...been unwilling or unable to confirm the existence identify a beneficial owner.

It now reads:

> ...been unwilling or unable to confirm the existence of or identify a beneficial owner.

## Translation files

The same string also appears as `msgid` entries in `docs/locale/{es,fr,ru}/LC_MESSAGES/codelist.po`. I left those alone because `msgid`s are normally regenerated from the English source via `pybabel extract` / `sphinx-intl update`. The existing translations will be flagged as fuzzy on the next extraction run and translators can confirm them.

## Test plan

- [x] Verified `schema/codelists/unspecifiedReason.csv` is still valid CSV and the only source occurrence of the typo
- [x] Maintainers: confirm whether the `.po` files should be regenerated in this PR or in a follow-up

https://claude.ai/code/session_019ksAaAodXk1wNCLcuEVkXC

---
_Generated by [Claude Code](https://claude.ai/code/session_019ksAaAodXk1wNCLcuEVkXC)_