### PR TITLE
Add json-pointer format to statementPointerTarget

### DIFF
--- a/schema/statement.json
+++ b/schema/statement.json
@@ -226,7 +226,8 @@
         "statementPointerTarget": {
           "title": "Statement Fragment Pointer",
           "description": "An RFC6901 JSON Pointer (https://tools.ietf.org/html/rfc6901) describing the target fragment of the statement that this Annotation applies to, starting from the root of the Statement. An empty string (\"\") indicates that the Annotation applies to the whole Statement.",
-          "type": "string"
+          "type": "string",
+          "format": "json-pointer"
         },
         "creationDate": {
           "title": "Creation Date",

--- a/tests/data/invalid-statements/expected_errors.csv
+++ b/tests/data/invalid-statements/expected_errors.csv
@@ -15,6 +15,7 @@ person_names_fullName_missing.json,required,$[0].recordDetails.names[0],fullName
 person_taxResidencies_no_object.json,type,$[0].recordDetails.taxResidencies,taxResidencies
 person_addresses_no_array.json,type,$[0].recordDetails.addresses,addresses
 statement_annotations_statementPointerTarget_type.json,type,$[0].annotations[0].statementPointerTarget,statementPointerTarget
+statement_annotations_statementPointerTarget_format.json,format,$[0].annotations[0].statementPointerTarget,statementPointerTarget
 entity_address_not_string.json,type,$[0].recordDetails.addresses[0].address,address
 entity_postcode_not_string.json,type,$[0].recordDetails.addresses[0].postCode,postCode
 entity_address_country_name_not_string.json,type,$[0].recordDetails.addresses[0].country.name,name

--- a/tests/data/invalid-statements/statement_annotations_statementPointerTarget_format.json
+++ b/tests/data/invalid-statements/statement_annotations_statementPointerTarget_format.json
@@ -1,0 +1,21 @@
+[
+  {
+    "statementId": "2f7bf9370f1254068e5e946df067d07d",
+    "declarationSubject": "xyz",
+    "statementDate": "2017-11-18",
+    "annotations": [
+      {
+        "statementPointerTarget": "recordDetails/interestedParty",
+        "motivation": "identifying"
+      }
+    ],
+    "recordId": "123",
+    "recordType": "entity",
+    "recordDetails": {
+      "entityType": {
+        "type": "unknownEntity"
+      },
+      "isComponent": false
+    }
+  }
+]


### PR DESCRIPTION
## Summary

Fixes #707.

The `statementPointerTarget` property on the `Annotation` object is described as an RFC6901 JSON Pointer but the schema only constrained it to `type: string`. This adds `"format": "json-pointer"` so validators reject values that are not well-formed pointers (e.g. missing leading `/` or containing invalid `~` escapes).

Change in `schema/statement.json`:

```diff
         "statementPointerTarget": {
           "title": "Statement Fragment Pointer",
           "description": "An RFC6901 JSON Pointer ...",
-          "type": "string"
+          "type": "string",
+          "format": "json-pointer"
         },
```

## Test plan

- [x] Added `tests/data/invalid-statements/statement_annotations_statementPointerTarget_format.json` with an invalid pointer (missing leading `/`)
- [x] Added matching row to `tests/data/invalid-statements/expected_errors.csv`
- [x] `pytest tests/test_data.py` — new test passes; no new failures (pre-existing 12 format-related failures on `main` in the local sandbox are environmental and unchanged here)
- [x] All existing valid fixtures use well-formed pointers (`""`, `/recordDetails/...`, `/statementDate`) so none break under the new constraint

https://claude.ai/code/session_019ksAaAodXk1wNCLcuEVkXC

---
_Generated by [Claude Code](https://claude.ai/code/session_019ksAaAodXk1wNCLcuEVkXC)_